### PR TITLE
fix #81 bug, cannot import folder with esmImport flag activated

### DIFF
--- a/packages/generator/src/files/generate-util.ts
+++ b/packages/generator/src/files/generate-util.ts
@@ -11,6 +11,7 @@ import {
 	jsDocType,
 	OVERRIDE_WARNING,
 	relativeFileImportPath,
+	relativeFolderImportPath,
 	tsCheck,
 	type,
 	typeCast
@@ -23,7 +24,7 @@ const getLocalesTranslationRowAsync = (locale: Locale): string => {
 	const wrappedLocale = needsEscaping ? `'${locale}'` : locale
 
 	return `
-	${wrappedLocale}: () => import('${relativeFileImportPath(locale)}'),`
+	${wrappedLocale}: () => import('${relativeFolderImportPath(locale)}'),`
 }
 
 const getAsyncCode = ({ locales }: GeneratorConfigWithDefaultValues) => {
@@ -72,7 +73,7 @@ const getSyncCode = ({ baseLocale, locales }: GeneratorConfigWithDefaultValues) 
 	const localesImports = locales
 		.map(
 			(locale) => `
-import ${sanitizeLocale(locale)} from '${relativeFileImportPath(locale)}'`,
+import ${sanitizeLocale(locale)} from '${relativeFolderImportPath(locale)}'`,
 		)
 		.join('')
 

--- a/packages/generator/src/output-handler.ts
+++ b/packages/generator/src/output-handler.ts
@@ -63,6 +63,8 @@ export const configureOutputHandler = (config: GeneratorConfigWithDefaultValues,
 	jsDocType = (type) => (shouldGenerateJsDoc ? `/** @type { ${type} } */` : '')
 
 	relativeFileImportPath = (fileName: string) => `./${fileName}${config.esmImports ? '.js' : ''}`
+
+	relativeFolderImportPath = (folderName: string) => `./${folderName}${config.esmImports ? '/index.js' : ''}`
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -93,3 +95,5 @@ export let jsDocFunction: (returnType: string, ...params: { type: string; name: 
 export let jsDocType: (type: string) => string
 
 export let relativeFileImportPath: (fileName: string) => string
+
+export let relativeFolderImportPath: (folderName: string) => string

--- a/packages/generator/test/generated/esm-imports-async-jsdoc/util.expected.js
+++ b/packages/generator/test/generated/esm-imports-async-jsdoc/util.expected.js
@@ -26,7 +26,7 @@ export const locales = [
 
 /** @type { Record<Locales, () => Promise<any>> } */
 const localeTranslationLoaders = {
-	en: () => import('./en.js'),
+	en: () => import('./en/index.js'),
 }
 
 /**

--- a/packages/generator/test/generated/esm-imports-async/util.expected.ts
+++ b/packages/generator/test/generated/esm-imports-async/util.expected.ts
@@ -14,7 +14,7 @@ export const locales: Locales[] = [
 ]
 
 const localeTranslationLoaders = {
-	en: () => import('./en.js'),
+	en: () => import('./en/index.js'),
 }
 
 export const getTranslationForLocale = async (locale: Locales) => (await (localeTranslationLoaders[locale] || localeTranslationLoaders[baseLocale])()).default as Translation

--- a/packages/generator/test/generated/esm-imports-sync-jsdoc/util.expected.js
+++ b/packages/generator/test/generated/esm-imports-sync-jsdoc/util.expected.js
@@ -25,7 +25,7 @@ export const locales = [
 	'en'
 ]
 
-import en from './en.js'
+import en from './en/index.js'
 
 /** @type { LocaleTranslations } */
 const localeTranslations = {

--- a/packages/generator/test/generated/esm-imports-sync/util.expected.ts
+++ b/packages/generator/test/generated/esm-imports-sync/util.expected.ts
@@ -14,7 +14,7 @@ export const locales: Locales[] = [
 	'en'
 ]
 
-import en from './en.js'
+import en from './en/index.js'
 
 const localeTranslations: LocaleTranslations<Locales, Translation> = {
 	en: en as Translation,


### PR DESCRIPTION
Fix #81  

You cannot import folder with esmImport flag activated.
I forgot to add support for folders.