### PR TITLE
[feat] add support for JSON imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 # CHANGELOG.md
 
-## [Unreleased]
+
+
+## 2.59.0 (2022-01-18)
 
 Feature:
 - add support for JSON files [#151](https://github.com/ivanhofer/typesafe-i18n/discussions/151)
 
 ## 2.58.0 (2022-01-09)
 
-Feat:
+Feature:
  - add better support for monorepos [#149](https://github.com/ivanhofer/typesafe-i18n/discussions/149)
 
 ## 2.57.7 (2022-01-09)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG.md
 
+## [Unreleased]
+
+Feature:
+- add support for JSON files [#151](https://github.com/ivanhofer/typesafe-i18n/discussions/151)
 
 ## 2.58.0 (2022-01-09)
 

--- a/packages/generator/src/parse-language-file.ts
+++ b/packages/generator/src/parse-language-file.ts
@@ -70,7 +70,7 @@ const transpileTypescriptFiles = async (
 	locale: string,
 	tempPath: string,
 ): Promise<string> => {
-	const program = ts.createProgram([languageFilePath], { outDir: tempPath, allowJs: true })
+	const program = ts.createProgram([languageFilePath], { outDir: tempPath, allowJs: true, resolveJsonModule: true })
 	program.emit()
 
 	const baseTranslationPath = await detectLocationOfCompiledBaseTranslation(outputPath, locale, tempPath)


### PR DESCRIPTION
With this change you can use JSON as the source for your translation texts. See #151

Then plain JSON can be used to store the texts (with `en` as the base language):

`src/i18n/en/index.ts`:
```ts
import * as en from './texts.json';
export default en;
```

`src/i18n/en/texts.json`:
```json
{
    "HI": "Hello {name}!",
    "BYE": "Bye bye"
}
```

`src/i18n/de/index.ts`:
```ts
import type { Translation } from '../i18n-types'
import * as deJson from './texts.json'
const de: Translation = deJson;
export default de
```

`src/i18n/en/texts.json`:
```json
{
    "HI": "Hallo {name}!",
    "BYE": "Auf Wiedersehen"
}
```



### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm run test` and lint the project with `pnpm run lint`

