### PR TITLE
feat: use esbuild for parsing base translation file

### DIFF
--- a/packages/cli/esbuild.ts
+++ b/packages/cli/esbuild.ts
@@ -17,7 +17,7 @@ build({
 	bundle: true,
 	outfile: getPath('../../cli/typesafe-i18n.mjs'),
 	platform: 'node',
-	external: ['typescript'],
+	external: ['typescript', 'esbuild'],
 	banner: {
 		js: `#!/usr/bin/env node
 import { createRequire } from 'module'

--- a/packages/exporter/esbuild.ts
+++ b/packages/exporter/esbuild.ts
@@ -18,7 +18,7 @@ formats.forEach((format) => {
 		bundle: true,
 		outfile: getPath(`../../exporter/index.${format === 'esm' ? 'm' : 'c'}js`),
 		platform: 'node',
-		external: ['typescript'],
+		external: ['typescript', 'esbuild'],
 		banner:
 			format === 'esm'
 				? {

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -3,6 +3,7 @@
   "devDependencies": {
     "@types/esutils": "^2.0.0",
     "chokidar": "^3.5.3",
+    "esbuild": "^0.14.23",
     "esutils": "^2.0.3",
     "kleur": "^4.1.4",
     "require-self": "^0.2.3",

--- a/packages/importer/esbuild.ts
+++ b/packages/importer/esbuild.ts
@@ -18,7 +18,7 @@ formats.forEach((format) => {
 		bundle: true,
 		outfile: getPath(`../../importer/index.${format === 'esm' ? 'm' : 'c'}js`),
 		platform: 'node',
-		external: ['typescript'],
+		external: ['typescript', 'esbuild'],
 		banner:
 			format === 'esm'
 				? {

--- a/packages/rollup-plugin/esbuild.ts
+++ b/packages/rollup-plugin/esbuild.ts
@@ -19,7 +19,7 @@ files.forEach((file) => {
 		bundle: true,
 		outfile: getPath(`../../rollup/${file.replace('.ts', '.js')}`),
 		platform: 'node',
-		external: ['typescript', 'chokidar'],
+		external: ['typescript', 'chokidar', 'esbuild'],
 		format: 'cjs',
 		sourcemap: watch,
 		watch,

--- a/packages/version.ts
+++ b/packages/version.ts
@@ -1,2 +1,2 @@
 // this file gets auto-generated
-export const version = '4.2.2'
+export const version = '4.3.0'

--- a/packages/webpack-plugin/esbuild.ts
+++ b/packages/webpack-plugin/esbuild.ts
@@ -15,7 +15,7 @@ build({
 	bundle: true,
 	outfile: getPath('../../webpack/webpack-plugin-typesafe-i18n.js'),
 	platform: 'node',
-	external: ['typescript', 'chokidar'],
+	external: ['typescript', 'chokidar', 'esbuild'],
 	format: 'cjs',
 	sourcemap: watch,
 	watch,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,7 @@ importers:
     specifiers:
       '@types/esutils': ^2.0.0
       chokidar: ^3.5.3
+      esbuild: ^0.14.23
       esutils: ^2.0.3
       kleur: ^4.1.4
       require-self: ^0.2.3
@@ -188,6 +189,7 @@ importers:
     devDependencies:
       '@types/esutils': 2.0.0
       chokidar: 3.5.3
+      esbuild: 0.14.23
       esutils: 2.0.3
       kleur: 4.1.4
       require-self: 0.2.3


### PR DESCRIPTION
This PR replaces the functionality to parse base translations via `tsc` with `esbuild`.

This has some advantages:
 - `ebuild` it is a lot faster than `tsc`
 - everything get's bundled into a single file
    No more hacky checking where the generated `index.js` file is located when imports are used in the translation file

But this approach brings some new questions:
 - can we include `esbuild` into the generated `cli`-bundle?
 - does `esbuild` need to be installed on the clients that run the `typseafe-i18n` generator?