### PR TITLE
Batch SolidJS updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 # Version 5
 
+## 5.3.6 (2022-04-12)
+
+Fix:
+ - update state with `batch` inside solid adapter
+
 ## 5.3.5 (2022-04-10)
 
 Fix:


### PR DESCRIPTION
Batches SolidJS updates to avoid UI thrashing when updating the two separate signals. Without this, any effects (including displayed text) will re-render twice if they use both `LL()` and `locale()`. 

I also cleaned up the initialization a bit. Unlike React, SolidJS component bodies only run once, so there is no need for the `!locale() &&` part. 