### PR TITLE
feat: break out translation imports into it's own functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # Version 5
 
+## 5.10.0 (2022-07-25)
+
+Feature:
+ - break out translation imports into it's own functions [#384](https://github.com/ivanhofer/typesafe-i18n/discussions/384)
+
 ## 5.9.1 (2022-07-25)
 
 Fix:

--- a/packages/generator/src/files/generate-util-async.mts
+++ b/packages/generator/src/files/generate-util-async.mts
@@ -11,7 +11,7 @@ import {
 	relativeFolderImportPath,
 	tsCheck,
 	type,
-	typeCast
+	typeCast,
 } from '../output-handler.mjs'
 import { writeFileIfContainsChanges } from '../utils/file.utils.mjs'
 import { prettify, wrapObjectKeyIfNeeded } from '../utils/generator.utils.mjs'

--- a/packages/generator/src/files/generate-util-async.mts
+++ b/packages/generator/src/files/generate-util-async.mts
@@ -37,6 +37,15 @@ const localeNamespaceLoaders = {
 }`
 
 	const namespaceLoader = `
+${jsDocFunction(
+	'Promise<Translations[namespace]>',
+	{ type: 'Locales', name: 'locale' },
+	{ type: 'Namespaces', name: 'namespace' },
+)}
+export const importNamespaceAsync = async${generics('Namespace extends Namespaces')}(locale${type(
+		'Locales',
+	)}, namespace${type('Namespace')}) =>
+	(await localeNamespaceLoaders[locale][namespace]()).default${typeCast('unknown')}${typeCast('Translations[Namespace]')}
 ${jsDocFunction('Promise<void>', { type: 'Locales', name: 'locale' }, { type: 'Namespaces', name: 'namespace' })}
 export const loadNamespaceAsync = async ${generics('Namespace extends Namespaces')}(locale${type(
 		'Locales',
@@ -45,16 +54,7 @@ export const loadNamespaceAsync = async ${generics('Namespace extends Namespaces
 		locale,
 		${jsDocType('Partial<Translations>', `{ [namespace]: await importNamespaceAsync(locale, namespace)}`)}
 	)
-
-${jsDocFunction(
-	'Promise<Partial<Translations>>',
-	{ type: 'Locales', name: 'locale' },
-	{ type: 'Namespaces', name: 'namespace' },
-)}
-export const importNamespaceAsync = async${generics('Namespace extends Namespaces')}(locale${type(
-		'Locales',
-	)}, namespace${type('Namespace')}) =>
-	(await localeNamespaceLoaders[locale][namespace]()).default${typeCast('unknown')}${typeCast('Partial<Translations>')};`
+`
 	return [namespaceImports, namespaceLoader]
 }
 

--- a/packages/generator/src/files/generate-util-async.mts
+++ b/packages/generator/src/files/generate-util-async.mts
@@ -11,7 +11,7 @@ import {
 	relativeFolderImportPath,
 	tsCheck,
 	type,
-	typeCast,
+	typeCast
 } from '../output-handler.mjs'
 import { writeFileIfContainsChanges } from '../utils/file.utils.mjs'
 import { prettify, wrapObjectKeyIfNeeded } from '../utils/generator.utils.mjs'
@@ -43,13 +43,14 @@ export const loadNamespaceAsync = async ${generics('Namespace extends Namespaces
 	)}, namespace${type('Namespace')})${type('Promise<void>')} =>
 	void updateDictionary(
 		locale,
-		${jsDocType(
-			'Partial<Translations>',
-			`{ [namespace]: await importNamespaceAsync(locale, namespace)}`,
-		)}
+		${jsDocType('Partial<Translations>', `{ [namespace]: await importNamespaceAsync(locale, namespace)}`)}
 	)
 
-${jsDocFunction('Promise<Partial<Translations>>', { type: 'Locales', name: 'locale' }, { type: 'Namespaces', name: 'namespace' })}
+${jsDocFunction(
+	'Promise<Partial<Translations>>',
+	{ type: 'Locales', name: 'locale' },
+	{ type: 'Namespaces', name: 'namespace' },
+)}
 export const importNamespaceAsync = async${generics('Namespace extends Namespaces')}(locale${type(
 		'Locales',
 	)}, namespace${type('Namespace')}) =>
@@ -68,7 +69,13 @@ const getAsyncCode = (
 	const translationImporter = `
 ${jsDocFunction('Promise<Translations>', { type: 'Locales', name: 'locale' })}
 export const importLocaleAsync = async (locale${type('Locales')}) =>
-	(await localeTranslationLoaders[locale]()).default${typeCast('unknown')}${typeCast('Translations')};
+	${jsDocType(
+		'Translations',
+		jsDocType(
+			'unknown',
+			`(await localeTranslationLoaders[locale]()).default${typeCast('unknown')}${typeCast('Translations')}`,
+		),
+	)}
 `
 
 	return `${OVERRIDE_WARNING}${tsCheck}
@@ -100,10 +107,7 @@ ${translationImporter}
 
 ${jsDocFunction('Promise<void>', { type: 'Locales', name: 'locale' })}
 export const loadLocaleAsync = async (locale${type('Locales')})${type('Promise<void>')} => {
-	updateDictionary(
-		locale,
-		${jsDocType('Translations', `await importLocaleAsync(locale)`)}
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/src/files/generate-util-async.mts
+++ b/packages/generator/src/files/generate-util-async.mts
@@ -50,10 +50,7 @@ ${jsDocFunction('Promise<void>', { type: 'Locales', name: 'locale' }, { type: 'N
 export const loadNamespaceAsync = async ${generics('Namespace extends Namespaces')}(locale${type(
 		'Locales',
 	)}, namespace${type('Namespace')})${type('Promise<void>')} =>
-	void updateDictionary(
-		locale,
-		${jsDocType('Partial<Translations>', `{ [namespace]: await importNamespaceAsync(locale, namespace)}`)}
-	)
+	void updateDictionary(locale, { [namespace]: await importNamespaceAsync(locale, namespace )})
 `
 	return [namespaceImports, namespaceLoader]
 }

--- a/packages/generator/src/files/generate-util-sync.mts
+++ b/packages/generator/src/files/generate-util-sync.mts
@@ -95,9 +95,8 @@ export const loadLocale = (locale${type('Locales')})${type('void')} => {
 export const loadAllLocales = ()${type('void')} => locales.forEach(loadLocale)
 
 ${jsDocFunction('void', { type: 'Locales', name: 'locale' })}
-export const loadFormatters = (locale${type('Locales')})${type('void')} => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale${type('Locales')})${type('void')} =>
+	void (loadedFormatters[locale] = initFormatters(locale))
 `
 }
 

--- a/packages/generator/test/generated/adapter-angular-esm/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-angular-esm/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-angular-esm/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-angular-esm/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-angular-esm/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-angular-esm/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapter-angular-esm/util.expected.sync.ts
+++ b/packages/generator/test/generated/adapter-angular-esm/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/adapter-angular/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-angular/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-angular/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-angular/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-angular/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-angular/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapter-angular/util.expected.sync.ts
+++ b/packages/generator/test/generated/adapter-angular/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/adapter-node-esm-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-node-esm-jsdoc/util.expected.async.js
@@ -28,17 +28,14 @@ const updateDictionary = (locale, dictionary) =>
  * @return { Promise<Translations> }
  */
 export const importLocaleAsync = async (locale) =>
-	(await localeTranslationLoaders[locale]()).default;
+	/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
 
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
  */
 export const loadLocaleAsync = async (locale) => {
-	updateDictionary(
-		locale,
-		/** @type { Translations } */ (await importLocaleAsync(locale))
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapter-node-esm-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-node-esm-jsdoc/util.expected.async.js
@@ -23,10 +23,12 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default;
-};
+/**
+ * @param { Locales } locale
+ * @return { Promise<Translations> }
+ */
+export const importLocaleAsync = async (locale) =>
+	(await localeTranslationLoaders[locale]()).default;
 
 /**
  * @param { Locales } locale
@@ -35,7 +37,7 @@ export const importTranslations = async (locale) => {
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
+		/** @type { Translations } */ (await importLocaleAsync(locale))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-node-esm-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-node-esm-jsdoc/util.expected.async.js
@@ -23,6 +23,11 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default;
+};
+
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
@@ -30,7 +35,7 @@ const updateDictionary = (locale, dictionary) =>
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
+		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-node-esm-jsdoc/util.expected.sync.js
+++ b/packages/generator/test/generated/adapter-node-esm-jsdoc/util.expected.sync.js
@@ -34,6 +34,5 @@ export const loadAllLocales = () => locales.forEach(loadLocale)
  * @param { Locales } locale
  * @return { void }
  */
-export const loadFormatters = (locale) => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale) =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/adapter-node-esm/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-node-esm/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-node-esm/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-node-esm/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-node-esm/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-node-esm/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapter-node-esm/util.expected.sync.ts
+++ b/packages/generator/test/generated/adapter-node-esm/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/adapter-node-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-node-jsdoc/util.expected.async.js
@@ -28,17 +28,14 @@ const updateDictionary = (locale, dictionary) =>
  * @return { Promise<Translations> }
  */
 export const importLocaleAsync = async (locale) =>
-	(await localeTranslationLoaders[locale]()).default;
+	/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
 
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
  */
 export const loadLocaleAsync = async (locale) => {
-	updateDictionary(
-		locale,
-		/** @type { Translations } */ (await importLocaleAsync(locale))
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapter-node-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-node-jsdoc/util.expected.async.js
@@ -23,10 +23,12 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default;
-};
+/**
+ * @param { Locales } locale
+ * @return { Promise<Translations> }
+ */
+export const importLocaleAsync = async (locale) =>
+	(await localeTranslationLoaders[locale]()).default;
 
 /**
  * @param { Locales } locale
@@ -35,7 +37,7 @@ export const importTranslations = async (locale) => {
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
+		/** @type { Translations } */ (await importLocaleAsync(locale))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-node-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-node-jsdoc/util.expected.async.js
@@ -23,6 +23,11 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default;
+};
+
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
@@ -30,7 +35,7 @@ const updateDictionary = (locale, dictionary) =>
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
+		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-node-jsdoc/util.expected.sync.js
+++ b/packages/generator/test/generated/adapter-node-jsdoc/util.expected.sync.js
@@ -34,6 +34,5 @@ export const loadAllLocales = () => locales.forEach(loadLocale)
  * @param { Locales } locale
  * @return { void }
  */
-export const loadFormatters = (locale) => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale) =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/adapter-node/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-node/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-node/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-node/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-node/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-node/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapter-node/util.expected.sync.ts
+++ b/packages/generator/test/generated/adapter-node/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/adapter-react-esm-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-react-esm-jsdoc/util.expected.async.js
@@ -28,17 +28,14 @@ const updateDictionary = (locale, dictionary) =>
  * @return { Promise<Translations> }
  */
 export const importLocaleAsync = async (locale) =>
-	(await localeTranslationLoaders[locale]()).default;
+	/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
 
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
  */
 export const loadLocaleAsync = async (locale) => {
-	updateDictionary(
-		locale,
-		/** @type { Translations } */ (await importLocaleAsync(locale))
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapter-react-esm-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-react-esm-jsdoc/util.expected.async.js
@@ -23,10 +23,12 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default;
-};
+/**
+ * @param { Locales } locale
+ * @return { Promise<Translations> }
+ */
+export const importLocaleAsync = async (locale) =>
+	(await localeTranslationLoaders[locale]()).default;
 
 /**
  * @param { Locales } locale
@@ -35,7 +37,7 @@ export const importTranslations = async (locale) => {
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
+		/** @type { Translations } */ (await importLocaleAsync(locale))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-react-esm-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-react-esm-jsdoc/util.expected.async.js
@@ -23,6 +23,11 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default;
+};
+
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
@@ -30,7 +35,7 @@ const updateDictionary = (locale, dictionary) =>
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
+		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-react-esm-jsdoc/util.expected.sync.js
+++ b/packages/generator/test/generated/adapter-react-esm-jsdoc/util.expected.sync.js
@@ -34,6 +34,5 @@ export const loadAllLocales = () => locales.forEach(loadLocale)
  * @param { Locales } locale
  * @return { void }
  */
-export const loadFormatters = (locale) => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale) =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/adapter-react-esm/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-react-esm/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-react-esm/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-react-esm/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-react-esm/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-react-esm/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapter-react-esm/util.expected.sync.ts
+++ b/packages/generator/test/generated/adapter-react-esm/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/adapter-react-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-react-jsdoc/util.expected.async.js
@@ -28,17 +28,14 @@ const updateDictionary = (locale, dictionary) =>
  * @return { Promise<Translations> }
  */
 export const importLocaleAsync = async (locale) =>
-	(await localeTranslationLoaders[locale]()).default;
+	/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
 
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
  */
 export const loadLocaleAsync = async (locale) => {
-	updateDictionary(
-		locale,
-		/** @type { Translations } */ (await importLocaleAsync(locale))
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapter-react-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-react-jsdoc/util.expected.async.js
@@ -23,10 +23,12 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default;
-};
+/**
+ * @param { Locales } locale
+ * @return { Promise<Translations> }
+ */
+export const importLocaleAsync = async (locale) =>
+	(await localeTranslationLoaders[locale]()).default;
 
 /**
  * @param { Locales } locale
@@ -35,7 +37,7 @@ export const importTranslations = async (locale) => {
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
+		/** @type { Translations } */ (await importLocaleAsync(locale))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-react-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-react-jsdoc/util.expected.async.js
@@ -23,6 +23,11 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default;
+};
+
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
@@ -30,7 +35,7 @@ const updateDictionary = (locale, dictionary) =>
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
+		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-react-jsdoc/util.expected.sync.js
+++ b/packages/generator/test/generated/adapter-react-jsdoc/util.expected.sync.js
@@ -34,6 +34,5 @@ export const loadAllLocales = () => locales.forEach(loadLocale)
  * @param { Locales } locale
  * @return { void }
  */
-export const loadFormatters = (locale) => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale) =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/adapter-react/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-react/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-react/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-react/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-react/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-react/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapter-react/util.expected.sync.ts
+++ b/packages/generator/test/generated/adapter-react/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/adapter-solid-esm-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-solid-esm-jsdoc/util.expected.async.js
@@ -28,17 +28,14 @@ const updateDictionary = (locale, dictionary) =>
  * @return { Promise<Translations> }
  */
 export const importLocaleAsync = async (locale) =>
-	(await localeTranslationLoaders[locale]()).default;
+	/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
 
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
  */
 export const loadLocaleAsync = async (locale) => {
-	updateDictionary(
-		locale,
-		/** @type { Translations } */ (await importLocaleAsync(locale))
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapter-solid-esm-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-solid-esm-jsdoc/util.expected.async.js
@@ -23,10 +23,12 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default;
-};
+/**
+ * @param { Locales } locale
+ * @return { Promise<Translations> }
+ */
+export const importLocaleAsync = async (locale) =>
+	(await localeTranslationLoaders[locale]()).default;
 
 /**
  * @param { Locales } locale
@@ -35,7 +37,7 @@ export const importTranslations = async (locale) => {
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
+		/** @type { Translations } */ (await importLocaleAsync(locale))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-solid-esm-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-solid-esm-jsdoc/util.expected.async.js
@@ -23,6 +23,11 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default;
+};
+
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
@@ -30,7 +35,7 @@ const updateDictionary = (locale, dictionary) =>
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
+		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-solid-esm-jsdoc/util.expected.sync.js
+++ b/packages/generator/test/generated/adapter-solid-esm-jsdoc/util.expected.sync.js
@@ -34,6 +34,5 @@ export const loadAllLocales = () => locales.forEach(loadLocale)
  * @param { Locales } locale
  * @return { void }
  */
-export const loadFormatters = (locale) => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale) =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/adapter-solid-esm/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-solid-esm/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-solid-esm/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-solid-esm/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-solid-esm/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-solid-esm/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapter-solid-esm/util.expected.sync.ts
+++ b/packages/generator/test/generated/adapter-solid-esm/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/adapter-solid-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-solid-jsdoc/util.expected.async.js
@@ -28,17 +28,14 @@ const updateDictionary = (locale, dictionary) =>
  * @return { Promise<Translations> }
  */
 export const importLocaleAsync = async (locale) =>
-	(await localeTranslationLoaders[locale]()).default;
+	/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
 
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
  */
 export const loadLocaleAsync = async (locale) => {
-	updateDictionary(
-		locale,
-		/** @type { Translations } */ (await importLocaleAsync(locale))
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapter-solid-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-solid-jsdoc/util.expected.async.js
@@ -23,10 +23,12 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default;
-};
+/**
+ * @param { Locales } locale
+ * @return { Promise<Translations> }
+ */
+export const importLocaleAsync = async (locale) =>
+	(await localeTranslationLoaders[locale]()).default;
 
 /**
  * @param { Locales } locale
@@ -35,7 +37,7 @@ export const importTranslations = async (locale) => {
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
+		/** @type { Translations } */ (await importLocaleAsync(locale))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-solid-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-solid-jsdoc/util.expected.async.js
@@ -23,6 +23,11 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default;
+};
+
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
@@ -30,7 +35,7 @@ const updateDictionary = (locale, dictionary) =>
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
+		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-solid-jsdoc/util.expected.sync.js
+++ b/packages/generator/test/generated/adapter-solid-jsdoc/util.expected.sync.js
@@ -34,6 +34,5 @@ export const loadAllLocales = () => locales.forEach(loadLocale)
  * @param { Locales } locale
  * @return { void }
  */
-export const loadFormatters = (locale) => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale) =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/adapter-solid/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-solid/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-solid/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-solid/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-solid/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-solid/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapter-solid/util.expected.sync.ts
+++ b/packages/generator/test/generated/adapter-solid/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/adapter-svelte-esm-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-svelte-esm-jsdoc/util.expected.async.js
@@ -28,17 +28,14 @@ const updateDictionary = (locale, dictionary) =>
  * @return { Promise<Translations> }
  */
 export const importLocaleAsync = async (locale) =>
-	(await localeTranslationLoaders[locale]()).default;
+	/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
 
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
  */
 export const loadLocaleAsync = async (locale) => {
-	updateDictionary(
-		locale,
-		/** @type { Translations } */ (await importLocaleAsync(locale))
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapter-svelte-esm-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-svelte-esm-jsdoc/util.expected.async.js
@@ -23,10 +23,12 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default;
-};
+/**
+ * @param { Locales } locale
+ * @return { Promise<Translations> }
+ */
+export const importLocaleAsync = async (locale) =>
+	(await localeTranslationLoaders[locale]()).default;
 
 /**
  * @param { Locales } locale
@@ -35,7 +37,7 @@ export const importTranslations = async (locale) => {
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
+		/** @type { Translations } */ (await importLocaleAsync(locale))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-svelte-esm-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-svelte-esm-jsdoc/util.expected.async.js
@@ -23,6 +23,11 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default;
+};
+
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
@@ -30,7 +35,7 @@ const updateDictionary = (locale, dictionary) =>
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
+		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-svelte-esm-jsdoc/util.expected.sync.js
+++ b/packages/generator/test/generated/adapter-svelte-esm-jsdoc/util.expected.sync.js
@@ -34,6 +34,5 @@ export const loadAllLocales = () => locales.forEach(loadLocale)
  * @param { Locales } locale
  * @return { void }
  */
-export const loadFormatters = (locale) => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale) =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/adapter-svelte-esm/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-svelte-esm/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-svelte-esm/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-svelte-esm/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-svelte-esm/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-svelte-esm/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapter-svelte-esm/util.expected.sync.ts
+++ b/packages/generator/test/generated/adapter-svelte-esm/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/adapter-svelte-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-svelte-jsdoc/util.expected.async.js
@@ -28,17 +28,14 @@ const updateDictionary = (locale, dictionary) =>
  * @return { Promise<Translations> }
  */
 export const importLocaleAsync = async (locale) =>
-	(await localeTranslationLoaders[locale]()).default;
+	/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
 
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
  */
 export const loadLocaleAsync = async (locale) => {
-	updateDictionary(
-		locale,
-		/** @type { Translations } */ (await importLocaleAsync(locale))
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapter-svelte-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-svelte-jsdoc/util.expected.async.js
@@ -23,10 +23,12 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default;
-};
+/**
+ * @param { Locales } locale
+ * @return { Promise<Translations> }
+ */
+export const importLocaleAsync = async (locale) =>
+	(await localeTranslationLoaders[locale]()).default;
 
 /**
  * @param { Locales } locale
@@ -35,7 +37,7 @@ export const importTranslations = async (locale) => {
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
+		/** @type { Translations } */ (await importLocaleAsync(locale))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-svelte-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-svelte-jsdoc/util.expected.async.js
@@ -23,6 +23,11 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default;
+};
+
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
@@ -30,7 +35,7 @@ const updateDictionary = (locale, dictionary) =>
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
+		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-svelte-jsdoc/util.expected.sync.js
+++ b/packages/generator/test/generated/adapter-svelte-jsdoc/util.expected.sync.js
@@ -34,6 +34,5 @@ export const loadAllLocales = () => locales.forEach(loadLocale)
  * @param { Locales } locale
  * @return { void }
  */
-export const loadFormatters = (locale) => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale) =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/adapter-svelte/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-svelte/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-svelte/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-svelte/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-svelte/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-svelte/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapter-svelte/util.expected.sync.ts
+++ b/packages/generator/test/generated/adapter-svelte/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/adapter-vue-esm-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-vue-esm-jsdoc/util.expected.async.js
@@ -28,17 +28,14 @@ const updateDictionary = (locale, dictionary) =>
  * @return { Promise<Translations> }
  */
 export const importLocaleAsync = async (locale) =>
-	(await localeTranslationLoaders[locale]()).default;
+	/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
 
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
  */
 export const loadLocaleAsync = async (locale) => {
-	updateDictionary(
-		locale,
-		/** @type { Translations } */ (await importLocaleAsync(locale))
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapter-vue-esm-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-vue-esm-jsdoc/util.expected.async.js
@@ -23,10 +23,12 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default;
-};
+/**
+ * @param { Locales } locale
+ * @return { Promise<Translations> }
+ */
+export const importLocaleAsync = async (locale) =>
+	(await localeTranslationLoaders[locale]()).default;
 
 /**
  * @param { Locales } locale
@@ -35,7 +37,7 @@ export const importTranslations = async (locale) => {
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
+		/** @type { Translations } */ (await importLocaleAsync(locale))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-vue-esm-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-vue-esm-jsdoc/util.expected.async.js
@@ -23,6 +23,11 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default;
+};
+
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
@@ -30,7 +35,7 @@ const updateDictionary = (locale, dictionary) =>
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
+		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-vue-esm-jsdoc/util.expected.sync.js
+++ b/packages/generator/test/generated/adapter-vue-esm-jsdoc/util.expected.sync.js
@@ -34,6 +34,5 @@ export const loadAllLocales = () => locales.forEach(loadLocale)
  * @param { Locales } locale
  * @return { void }
  */
-export const loadFormatters = (locale) => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale) =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/adapter-vue-esm/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-vue-esm/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-vue-esm/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-vue-esm/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-vue-esm/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-vue-esm/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapter-vue-esm/util.expected.sync.ts
+++ b/packages/generator/test/generated/adapter-vue-esm/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/adapter-vue-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-vue-jsdoc/util.expected.async.js
@@ -28,17 +28,14 @@ const updateDictionary = (locale, dictionary) =>
  * @return { Promise<Translations> }
  */
 export const importLocaleAsync = async (locale) =>
-	(await localeTranslationLoaders[locale]()).default;
+	/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
 
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
  */
 export const loadLocaleAsync = async (locale) => {
-	updateDictionary(
-		locale,
-		/** @type { Translations } */ (await importLocaleAsync(locale))
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapter-vue-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-vue-jsdoc/util.expected.async.js
@@ -23,10 +23,12 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default;
-};
+/**
+ * @param { Locales } locale
+ * @return { Promise<Translations> }
+ */
+export const importLocaleAsync = async (locale) =>
+	(await localeTranslationLoaders[locale]()).default;
 
 /**
  * @param { Locales } locale
@@ -35,7 +37,7 @@ export const importTranslations = async (locale) => {
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
+		/** @type { Translations } */ (await importLocaleAsync(locale))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-vue-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/adapter-vue-jsdoc/util.expected.async.js
@@ -23,6 +23,11 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default;
+};
+
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
@@ -30,7 +35,7 @@ const updateDictionary = (locale, dictionary) =>
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
+		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-vue-jsdoc/util.expected.sync.js
+++ b/packages/generator/test/generated/adapter-vue-jsdoc/util.expected.sync.js
@@ -34,6 +34,5 @@ export const loadAllLocales = () => locales.forEach(loadLocale)
  * @param { Locales } locale
  * @return { void }
  */
-export const loadFormatters = (locale) => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale) =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/adapter-vue/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-vue/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-vue/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-vue/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapter-vue/util.expected.async.ts
+++ b/packages/generator/test/generated/adapter-vue/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapter-vue/util.expected.sync.ts
+++ b/packages/generator/test/generated/adapter-vue/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/adapters-angular/util.expected.async.ts
+++ b/packages/generator/test/generated/adapters-angular/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapters-angular/util.expected.async.ts
+++ b/packages/generator/test/generated/adapters-angular/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapters-angular/util.expected.async.ts
+++ b/packages/generator/test/generated/adapters-angular/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapters-angular/util.expected.sync.ts
+++ b/packages/generator/test/generated/adapters-angular/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/adapters-empty/util.expected.async.ts
+++ b/packages/generator/test/generated/adapters-empty/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapters-empty/util.expected.async.ts
+++ b/packages/generator/test/generated/adapters-empty/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapters-empty/util.expected.async.ts
+++ b/packages/generator/test/generated/adapters-empty/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapters-empty/util.expected.sync.ts
+++ b/packages/generator/test/generated/adapters-empty/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/adapters-node-react/util.expected.async.ts
+++ b/packages/generator/test/generated/adapters-node-react/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapters-node-react/util.expected.async.ts
+++ b/packages/generator/test/generated/adapters-node-react/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapters-node-react/util.expected.async.ts
+++ b/packages/generator/test/generated/adapters-node-react/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapters-node-react/util.expected.sync.ts
+++ b/packages/generator/test/generated/adapters-node-react/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/adapters-react-svelte-vue/util.expected.async.ts
+++ b/packages/generator/test/generated/adapters-react-svelte-vue/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapters-react-svelte-vue/util.expected.async.ts
+++ b/packages/generator/test/generated/adapters-react-svelte-vue/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/adapters-react-svelte-vue/util.expected.async.ts
+++ b/packages/generator/test/generated/adapters-react-svelte-vue/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/adapters-react-svelte-vue/util.expected.sync.ts
+++ b/packages/generator/test/generated/adapters-react-svelte-vue/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/arg-order/util.expected.async.ts
+++ b/packages/generator/test/generated/arg-order/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/arg-order/util.expected.async.ts
+++ b/packages/generator/test/generated/arg-order/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/arg-order/util.expected.async.ts
+++ b/packages/generator/test/generated/arg-order/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/arg-order/util.expected.sync.ts
+++ b/packages/generator/test/generated/arg-order/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/arg-type-localized-string/util.expected.async.ts
+++ b/packages/generator/test/generated/arg-type-localized-string/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/arg-type-localized-string/util.expected.async.ts
+++ b/packages/generator/test/generated/arg-type-localized-string/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/arg-type-localized-string/util.expected.async.ts
+++ b/packages/generator/test/generated/arg-type-localized-string/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/arg-type-localized-string/util.expected.sync.ts
+++ b/packages/generator/test/generated/arg-type-localized-string/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/arg-types-with-external-type/util.expected.async.ts
+++ b/packages/generator/test/generated/arg-types-with-external-type/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/arg-types-with-external-type/util.expected.async.ts
+++ b/packages/generator/test/generated/arg-types-with-external-type/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/arg-types-with-external-type/util.expected.async.ts
+++ b/packages/generator/test/generated/arg-types-with-external-type/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/arg-types-with-external-type/util.expected.sync.ts
+++ b/packages/generator/test/generated/arg-types-with-external-type/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/arg-types/util.expected.async.ts
+++ b/packages/generator/test/generated/arg-types/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/arg-types/util.expected.async.ts
+++ b/packages/generator/test/generated/arg-types/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/arg-types/util.expected.async.ts
+++ b/packages/generator/test/generated/arg-types/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/arg-types/util.expected.sync.ts
+++ b/packages/generator/test/generated/arg-types/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/arrays-nested/util.expected.async.ts
+++ b/packages/generator/test/generated/arrays-nested/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/arrays-nested/util.expected.async.ts
+++ b/packages/generator/test/generated/arrays-nested/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/arrays-nested/util.expected.async.ts
+++ b/packages/generator/test/generated/arrays-nested/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/arrays-nested/util.expected.sync.ts
+++ b/packages/generator/test/generated/arrays-nested/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/arrays-root-strings/util.expected.async.ts
+++ b/packages/generator/test/generated/arrays-root-strings/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/arrays-root-strings/util.expected.async.ts
+++ b/packages/generator/test/generated/arrays-root-strings/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/arrays-root-strings/util.expected.async.ts
+++ b/packages/generator/test/generated/arrays-root-strings/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/arrays-root-strings/util.expected.sync.ts
+++ b/packages/generator/test/generated/arrays-root-strings/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/arrays-root/util.expected.async.ts
+++ b/packages/generator/test/generated/arrays-root/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/arrays-root/util.expected.async.ts
+++ b/packages/generator/test/generated/arrays-root/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/arrays-root/util.expected.async.ts
+++ b/packages/generator/test/generated/arrays-root/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/arrays-root/util.expected.sync.ts
+++ b/packages/generator/test/generated/arrays-root/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/banner-tslint/util.expected.async.ts
+++ b/packages/generator/test/generated/banner-tslint/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/banner-tslint/util.expected.async.ts
+++ b/packages/generator/test/generated/banner-tslint/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/banner-tslint/util.expected.async.ts
+++ b/packages/generator/test/generated/banner-tslint/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/banner-tslint/util.expected.sync.ts
+++ b/packages/generator/test/generated/banner-tslint/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/base-locale-de/util.expected.async.ts
+++ b/packages/generator/test/generated/base-locale-de/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/base-locale-de/util.expected.async.ts
+++ b/packages/generator/test/generated/base-locale-de/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/base-locale-de/util.expected.async.ts
+++ b/packages/generator/test/generated/base-locale-de/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/base-locale-de/util.expected.sync.ts
+++ b/packages/generator/test/generated/base-locale-de/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/empty-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/empty-jsdoc/util.expected.async.js
@@ -28,17 +28,14 @@ const updateDictionary = (locale, dictionary) =>
  * @return { Promise<Translations> }
  */
 export const importLocaleAsync = async (locale) =>
-	(await localeTranslationLoaders[locale]()).default;
+	/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
 
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
  */
 export const loadLocaleAsync = async (locale) => {
-	updateDictionary(
-		locale,
-		/** @type { Translations } */ (await importLocaleAsync(locale))
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/empty-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/empty-jsdoc/util.expected.async.js
@@ -23,10 +23,12 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default;
-};
+/**
+ * @param { Locales } locale
+ * @return { Promise<Translations> }
+ */
+export const importLocaleAsync = async (locale) =>
+	(await localeTranslationLoaders[locale]()).default;
 
 /**
  * @param { Locales } locale
@@ -35,7 +37,7 @@ export const importTranslations = async (locale) => {
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
+		/** @type { Translations } */ (await importLocaleAsync(locale))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/empty-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/empty-jsdoc/util.expected.async.js
@@ -23,6 +23,11 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default;
+};
+
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
@@ -30,7 +35,7 @@ const updateDictionary = (locale, dictionary) =>
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
+		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/empty-jsdoc/util.expected.sync.js
+++ b/packages/generator/test/generated/empty-jsdoc/util.expected.sync.js
@@ -34,6 +34,5 @@ export const loadAllLocales = () => locales.forEach(loadLocale)
  * @param { Locales } locale
  * @return { void }
  */
-export const loadFormatters = (locale) => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale) =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/empty/util.expected.async.ts
+++ b/packages/generator/test/generated/empty/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/empty/util.expected.async.ts
+++ b/packages/generator/test/generated/empty/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/empty/util.expected.async.ts
+++ b/packages/generator/test/generated/empty/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/empty/util.expected.sync.ts
+++ b/packages/generator/test/generated/empty/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/esm-imports-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/esm-imports-jsdoc/util.expected.async.js
@@ -28,17 +28,14 @@ const updateDictionary = (locale, dictionary) =>
  * @return { Promise<Translations> }
  */
 export const importLocaleAsync = async (locale) =>
-	(await localeTranslationLoaders[locale]()).default;
+	/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
 
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
  */
 export const loadLocaleAsync = async (locale) => {
-	updateDictionary(
-		locale,
-		/** @type { Translations } */ (await importLocaleAsync(locale))
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/esm-imports-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/esm-imports-jsdoc/util.expected.async.js
@@ -23,10 +23,12 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default;
-};
+/**
+ * @param { Locales } locale
+ * @return { Promise<Translations> }
+ */
+export const importLocaleAsync = async (locale) =>
+	(await localeTranslationLoaders[locale]()).default;
 
 /**
  * @param { Locales } locale
@@ -35,7 +37,7 @@ export const importTranslations = async (locale) => {
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
+		/** @type { Translations } */ (await importLocaleAsync(locale))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/esm-imports-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/esm-imports-jsdoc/util.expected.async.js
@@ -23,6 +23,11 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default;
+};
+
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
@@ -30,7 +35,7 @@ const updateDictionary = (locale, dictionary) =>
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
+		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/esm-imports-jsdoc/util.expected.sync.js
+++ b/packages/generator/test/generated/esm-imports-jsdoc/util.expected.sync.js
@@ -34,6 +34,5 @@ export const loadAllLocales = () => locales.forEach(loadLocale)
  * @param { Locales } locale
  * @return { void }
  */
-export const loadFormatters = (locale) => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale) =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/esm-imports/util.expected.async.ts
+++ b/packages/generator/test/generated/esm-imports/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/esm-imports/util.expected.async.ts
+++ b/packages/generator/test/generated/esm-imports/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/esm-imports/util.expected.async.ts
+++ b/packages/generator/test/generated/esm-imports/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/esm-imports/util.expected.sync.ts
+++ b/packages/generator/test/generated/esm-imports/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/formatter-chaining/util.expected.async.ts
+++ b/packages/generator/test/generated/formatter-chaining/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/formatter-chaining/util.expected.async.ts
+++ b/packages/generator/test/generated/formatter-chaining/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/formatter-chaining/util.expected.async.ts
+++ b/packages/generator/test/generated/formatter-chaining/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/formatter-chaining/util.expected.sync.ts
+++ b/packages/generator/test/generated/formatter-chaining/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/formatter-with-different-arg-types/util.expected.async.ts
+++ b/packages/generator/test/generated/formatter-with-different-arg-types/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/formatter-with-different-arg-types/util.expected.async.ts
+++ b/packages/generator/test/generated/formatter-with-different-arg-types/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/formatter-with-different-arg-types/util.expected.async.ts
+++ b/packages/generator/test/generated/formatter-with-different-arg-types/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/formatter-with-different-arg-types/util.expected.sync.ts
+++ b/packages/generator/test/generated/formatter-with-different-arg-types/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/formatter-with-multiple-usage/util.expected.async.ts
+++ b/packages/generator/test/generated/formatter-with-multiple-usage/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/formatter-with-multiple-usage/util.expected.async.ts
+++ b/packages/generator/test/generated/formatter-with-multiple-usage/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/formatter-with-multiple-usage/util.expected.async.ts
+++ b/packages/generator/test/generated/formatter-with-multiple-usage/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/formatter-with-multiple-usage/util.expected.sync.ts
+++ b/packages/generator/test/generated/formatter-with-multiple-usage/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/formatters-with-dashes/util.expected.async.ts
+++ b/packages/generator/test/generated/formatters-with-dashes/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/formatters-with-dashes/util.expected.async.ts
+++ b/packages/generator/test/generated/formatters-with-dashes/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/formatters-with-dashes/util.expected.async.ts
+++ b/packages/generator/test/generated/formatters-with-dashes/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/formatters-with-dashes/util.expected.sync.ts
+++ b/packages/generator/test/generated/formatters-with-dashes/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/formatters-with-spaces/util.expected.async.ts
+++ b/packages/generator/test/generated/formatters-with-spaces/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/formatters-with-spaces/util.expected.async.ts
+++ b/packages/generator/test/generated/formatters-with-spaces/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/formatters-with-spaces/util.expected.async.ts
+++ b/packages/generator/test/generated/formatters-with-spaces/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/formatters-with-spaces/util.expected.sync.ts
+++ b/packages/generator/test/generated/formatters-with-spaces/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/keyed-params/util.expected.async.ts
+++ b/packages/generator/test/generated/keyed-params/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/keyed-params/util.expected.async.ts
+++ b/packages/generator/test/generated/keyed-params/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/keyed-params/util.expected.async.ts
+++ b/packages/generator/test/generated/keyed-params/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/keyed-params/util.expected.sync.ts
+++ b/packages/generator/test/generated/keyed-params/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/locale-with-dash/util.expected.async.ts
+++ b/packages/generator/test/generated/locale-with-dash/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/locale-with-dash/util.expected.async.ts
+++ b/packages/generator/test/generated/locale-with-dash/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/locale-with-dash/util.expected.async.ts
+++ b/packages/generator/test/generated/locale-with-dash/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/locale-with-dash/util.expected.sync.ts
+++ b/packages/generator/test/generated/locale-with-dash/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/locales-with-dash/util.expected.async.ts
+++ b/packages/generator/test/generated/locales-with-dash/util.expected.async.ts
@@ -15,13 +15,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/locales-with-dash/util.expected.async.ts
+++ b/packages/generator/test/generated/locales-with-dash/util.expected.async.ts
@@ -14,10 +14,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/locales-with-dash/util.expected.async.ts
+++ b/packages/generator/test/generated/locales-with-dash/util.expected.async.ts
@@ -14,15 +14,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/locales-with-dash/util.expected.sync.ts
+++ b/packages/generator/test/generated/locales-with-dash/util.expected.sync.ts
@@ -24,6 +24,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/multiple-locales/util.expected.async.ts
+++ b/packages/generator/test/generated/multiple-locales/util.expected.async.ts
@@ -15,13 +15,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/multiple-locales/util.expected.async.ts
+++ b/packages/generator/test/generated/multiple-locales/util.expected.async.ts
@@ -14,10 +14,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/multiple-locales/util.expected.async.ts
+++ b/packages/generator/test/generated/multiple-locales/util.expected.async.ts
@@ -14,15 +14,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/multiple-locales/util.expected.sync.ts
+++ b/packages/generator/test/generated/multiple-locales/util.expected.sync.ts
@@ -24,6 +24,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/namespaces-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/namespaces-jsdoc/util.expected.async.js
@@ -30,6 +30,15 @@ const localeNamespaceLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (
+locale,
+	namespace?) => {
+	const loader = namespace
+		? localeNamespaceLoaders[locale][namespace]
+		: localeTranslationLoaders[locale];
+	return (await loader()).default;
+};
+
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
@@ -37,7 +46,7 @@ const updateDictionary = (locale, dictionary) =>
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
+		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
 	)
 	loadFormatters(locale)
 }
@@ -59,5 +68,5 @@ export const loadFormatters = (locale) =>
 export const loadNamespaceAsync = async (locale, namespace) =>
 	void updateDictionary(
 		locale,
-		/** @type { Partial<Translations> } */ (/** @type { unknown } */ ({ [namespace]: (await (localeNamespaceLoaders[locale][namespace])()).default }))
+		/** @type { Partial<Translations> } */ (/** @type { unknown } */ ({ [namespace]: (await importTranslations(locale, namespace))}))
 	)

--- a/packages/generator/test/generated/namespaces-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/namespaces-jsdoc/util.expected.async.js
@@ -58,6 +58,14 @@ export const loadFormatters = (locale) =>
 /**
  * @param { Locales } locale
  * @param { Namespaces } namespace
+ * @return { Promise<Translations[namespace]> }
+ */
+export const importNamespaceAsync = async(locale, namespace) =>
+	(await localeNamespaceLoaders[locale][namespace]()).default
+
+/**
+ * @param { Locales } locale
+ * @param { Namespaces } namespace
  * @return { Promise<void> }
  */
 export const loadNamespaceAsync = async (locale, namespace) =>
@@ -65,11 +73,3 @@ export const loadNamespaceAsync = async (locale, namespace) =>
 		locale,
 		/** @type { Partial<Translations> } */ ({ [namespace]: await importNamespaceAsync(locale, namespace)})
 	)
-
-/**
- * @param { Locales } locale
- * @param { Namespaces } namespace
- * @return { Promise<Partial<Translations>> }
- */
-export const importNamespaceAsync = async(locale, namespace) =>
-	(await localeNamespaceLoaders[locale][namespace]()).default;

--- a/packages/generator/test/generated/namespaces-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/namespaces-jsdoc/util.expected.async.js
@@ -30,14 +30,12 @@ const localeNamespaceLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (
-locale,
-	namespace?) => {
-	const loader = namespace
-		? localeNamespaceLoaders[locale][namespace]
-		: localeTranslationLoaders[locale];
-	return (await loader()).default;
-};
+/**
+ * @param { Locales } locale
+ * @return { Promise<Translations> }
+ */
+export const importLocaleAsync = async (locale) =>
+	(await localeTranslationLoaders[locale]()).default;
 
 /**
  * @param { Locales } locale
@@ -46,7 +44,7 @@ locale,
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
+		/** @type { Translations } */ (await importLocaleAsync(locale))
 	)
 	loadFormatters(locale)
 }
@@ -68,5 +66,13 @@ export const loadFormatters = (locale) =>
 export const loadNamespaceAsync = async (locale, namespace) =>
 	void updateDictionary(
 		locale,
-		/** @type { Partial<Translations> } */ (/** @type { unknown } */ ({ [namespace]: (await importTranslations(locale, namespace))}))
+		/** @type { Partial<Translations> } */ ({ [namespace]: await importNamespaceAsync(locale, namespace)})
 	)
+
+/**
+ * @param { Locales } locale
+ * @param { Namespaces } namespace
+ * @return { Promise<Partial<Translations>> }
+ */
+export const importNamespaceAsync = async(locale, namespace) =>
+	(await localeNamespaceLoaders[locale][namespace]()).default;

--- a/packages/generator/test/generated/namespaces-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/namespaces-jsdoc/util.expected.async.js
@@ -35,17 +35,14 @@ const updateDictionary = (locale, dictionary) =>
  * @return { Promise<Translations> }
  */
 export const importLocaleAsync = async (locale) =>
-	(await localeTranslationLoaders[locale]()).default;
+	/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
 
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
  */
 export const loadLocaleAsync = async (locale) => {
-	updateDictionary(
-		locale,
-		/** @type { Translations } */ (await importLocaleAsync(locale))
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/namespaces-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/namespaces-jsdoc/util.expected.async.js
@@ -69,7 +69,4 @@ export const importNamespaceAsync = async(locale, namespace) =>
  * @return { Promise<void> }
  */
 export const loadNamespaceAsync = async (locale, namespace) =>
-	void updateDictionary(
-		locale,
-		/** @type { Partial<Translations> } */ ({ [namespace]: await importNamespaceAsync(locale, namespace)})
-	)
+	void updateDictionary(locale, { [namespace]: await importNamespaceAsync(locale, namespace )})

--- a/packages/generator/test/generated/namespaces-jsdoc/util.expected.sync.js
+++ b/packages/generator/test/generated/namespaces-jsdoc/util.expected.sync.js
@@ -39,6 +39,5 @@ export const loadAllLocales = () => locales.forEach(loadLocale)
  * @param { Locales } locale
  * @return { void }
  */
-export const loadFormatters = (locale) => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale) =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/namespaces-multiple-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/namespaces-multiple-jsdoc/util.expected.async.js
@@ -61,6 +61,14 @@ export const loadFormatters = (locale) =>
 /**
  * @param { Locales } locale
  * @param { Namespaces } namespace
+ * @return { Promise<Translations[namespace]> }
+ */
+export const importNamespaceAsync = async(locale, namespace) =>
+	(await localeNamespaceLoaders[locale][namespace]()).default
+
+/**
+ * @param { Locales } locale
+ * @param { Namespaces } namespace
  * @return { Promise<void> }
  */
 export const loadNamespaceAsync = async (locale, namespace) =>
@@ -68,11 +76,3 @@ export const loadNamespaceAsync = async (locale, namespace) =>
 		locale,
 		/** @type { Partial<Translations> } */ ({ [namespace]: await importNamespaceAsync(locale, namespace)})
 	)
-
-/**
- * @param { Locales } locale
- * @param { Namespaces } namespace
- * @return { Promise<Partial<Translations>> }
- */
-export const importNamespaceAsync = async(locale, namespace) =>
-	(await localeNamespaceLoaders[locale][namespace]()).default;

--- a/packages/generator/test/generated/namespaces-multiple-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/namespaces-multiple-jsdoc/util.expected.async.js
@@ -33,6 +33,15 @@ const localeNamespaceLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (
+locale,
+	namespace?) => {
+	const loader = namespace
+		? localeNamespaceLoaders[locale][namespace]
+		: localeTranslationLoaders[locale];
+	return (await loader()).default;
+};
+
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
@@ -40,7 +49,7 @@ const updateDictionary = (locale, dictionary) =>
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
+		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
 	)
 	loadFormatters(locale)
 }
@@ -62,5 +71,5 @@ export const loadFormatters = (locale) =>
 export const loadNamespaceAsync = async (locale, namespace) =>
 	void updateDictionary(
 		locale,
-		/** @type { Partial<Translations> } */ (/** @type { unknown } */ ({ [namespace]: (await (localeNamespaceLoaders[locale][namespace])()).default }))
+		/** @type { Partial<Translations> } */ (/** @type { unknown } */ ({ [namespace]: (await importTranslations(locale, namespace))}))
 	)

--- a/packages/generator/test/generated/namespaces-multiple-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/namespaces-multiple-jsdoc/util.expected.async.js
@@ -38,17 +38,14 @@ const updateDictionary = (locale, dictionary) =>
  * @return { Promise<Translations> }
  */
 export const importLocaleAsync = async (locale) =>
-	(await localeTranslationLoaders[locale]()).default;
+	/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
 
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
  */
 export const loadLocaleAsync = async (locale) => {
-	updateDictionary(
-		locale,
-		/** @type { Translations } */ (await importLocaleAsync(locale))
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/namespaces-multiple-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/namespaces-multiple-jsdoc/util.expected.async.js
@@ -72,7 +72,4 @@ export const importNamespaceAsync = async(locale, namespace) =>
  * @return { Promise<void> }
  */
 export const loadNamespaceAsync = async (locale, namespace) =>
-	void updateDictionary(
-		locale,
-		/** @type { Partial<Translations> } */ ({ [namespace]: await importNamespaceAsync(locale, namespace)})
-	)
+	void updateDictionary(locale, { [namespace]: await importNamespaceAsync(locale, namespace )})

--- a/packages/generator/test/generated/namespaces-multiple-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/namespaces-multiple-jsdoc/util.expected.async.js
@@ -33,14 +33,12 @@ const localeNamespaceLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (
-locale,
-	namespace?) => {
-	const loader = namespace
-		? localeNamespaceLoaders[locale][namespace]
-		: localeTranslationLoaders[locale];
-	return (await loader()).default;
-};
+/**
+ * @param { Locales } locale
+ * @return { Promise<Translations> }
+ */
+export const importLocaleAsync = async (locale) =>
+	(await localeTranslationLoaders[locale]()).default;
 
 /**
  * @param { Locales } locale
@@ -49,7 +47,7 @@ locale,
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
+		/** @type { Translations } */ (await importLocaleAsync(locale))
 	)
 	loadFormatters(locale)
 }
@@ -71,5 +69,13 @@ export const loadFormatters = (locale) =>
 export const loadNamespaceAsync = async (locale, namespace) =>
 	void updateDictionary(
 		locale,
-		/** @type { Partial<Translations> } */ (/** @type { unknown } */ ({ [namespace]: (await importTranslations(locale, namespace))}))
+		/** @type { Partial<Translations> } */ ({ [namespace]: await importNamespaceAsync(locale, namespace)})
 	)
+
+/**
+ * @param { Locales } locale
+ * @param { Namespaces } namespace
+ * @return { Promise<Partial<Translations>> }
+ */
+export const importNamespaceAsync = async(locale, namespace) =>
+	(await localeNamespaceLoaders[locale][namespace]()).default;

--- a/packages/generator/test/generated/namespaces-multiple-jsdoc/util.expected.sync.js
+++ b/packages/generator/test/generated/namespaces-multiple-jsdoc/util.expected.sync.js
@@ -45,6 +45,5 @@ export const loadAllLocales = () => locales.forEach(loadLocale)
  * @param { Locales } locale
  * @return { void }
  */
-export const loadFormatters = (locale) => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale) =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/namespaces-multiple/util.expected.async.ts
+++ b/packages/generator/test/generated/namespaces-multiple/util.expected.async.ts
@@ -21,19 +21,13 @@ const localeNamespaceLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async <Namespace extends Namespaces>(
-locale: Locales,
-	namespace?: Namespace) => {
-	const loader = namespace
-		? localeNamespaceLoaders[locale][namespace]
-		: localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }
@@ -46,5 +40,8 @@ export const loadFormatters = (locale: Locales): void =>
 export const loadNamespaceAsync = async <Namespace extends Namespaces>(locale: Locales, namespace: Namespace): Promise<void> =>
 	void updateDictionary(
 		locale,
-		{ [namespace]: (await importTranslations(locale, namespace))} as Partial<Translations>
+		{ [namespace]: await importNamespaceAsync(locale, namespace)}
 	)
+
+export const importNamespaceAsync = async<Namespace extends Namespaces>(locale: Locales, namespace: Namespace) =>
+	(await localeNamespaceLoaders[locale][namespace]()).default as unknown as Partial<Translations>;

--- a/packages/generator/test/generated/namespaces-multiple/util.expected.async.ts
+++ b/packages/generator/test/generated/namespaces-multiple/util.expected.async.ts
@@ -34,11 +34,11 @@ export const loadAllLocalesAsync = (): Promise<void[]> => Promise.all(locales.ma
 export const loadFormatters = (locale: Locales): void =>
 	void (loadedFormatters[locale] = initFormatters(locale))
 
+export const importNamespaceAsync = async<Namespace extends Namespaces>(locale: Locales, namespace: Namespace) =>
+	(await localeNamespaceLoaders[locale][namespace]()).default as unknown as Translations[Namespace]
+
 export const loadNamespaceAsync = async <Namespace extends Namespaces>(locale: Locales, namespace: Namespace): Promise<void> =>
 	void updateDictionary(
 		locale,
 		{ [namespace]: await importNamespaceAsync(locale, namespace)}
 	)
-
-export const importNamespaceAsync = async<Namespace extends Namespaces>(locale: Locales, namespace: Namespace) =>
-	(await localeNamespaceLoaders[locale][namespace]()).default as unknown as Partial<Translations>;

--- a/packages/generator/test/generated/namespaces-multiple/util.expected.async.ts
+++ b/packages/generator/test/generated/namespaces-multiple/util.expected.async.ts
@@ -22,13 +22,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/namespaces-multiple/util.expected.async.ts
+++ b/packages/generator/test/generated/namespaces-multiple/util.expected.async.ts
@@ -38,7 +38,4 @@ export const importNamespaceAsync = async<Namespace extends Namespaces>(locale: 
 	(await localeNamespaceLoaders[locale][namespace]()).default as unknown as Translations[Namespace]
 
 export const loadNamespaceAsync = async <Namespace extends Namespaces>(locale: Locales, namespace: Namespace): Promise<void> =>
-	void updateDictionary(
-		locale,
-		{ [namespace]: await importNamespaceAsync(locale, namespace)}
-	)
+	void updateDictionary(locale, { [namespace]: await importNamespaceAsync(locale, namespace )})

--- a/packages/generator/test/generated/namespaces-multiple/util.expected.async.ts
+++ b/packages/generator/test/generated/namespaces-multiple/util.expected.async.ts
@@ -21,10 +21,19 @@ const localeNamespaceLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async <Namespace extends Namespaces>(
+locale: Locales,
+	namespace?: Namespace) => {
+	const loader = namespace
+		? localeNamespaceLoaders[locale][namespace]
+		: localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }
@@ -37,5 +46,5 @@ export const loadFormatters = (locale: Locales): void =>
 export const loadNamespaceAsync = async <Namespace extends Namespaces>(locale: Locales, namespace: Namespace): Promise<void> =>
 	void updateDictionary(
 		locale,
-		{ [namespace]: (await (localeNamespaceLoaders[locale][namespace])()).default } as unknown as Partial<Translations>
+		{ [namespace]: (await importTranslations(locale, namespace))} as Partial<Translations>
 	)

--- a/packages/generator/test/generated/namespaces-multiple/util.expected.sync.ts
+++ b/packages/generator/test/generated/namespaces-multiple/util.expected.sync.ts
@@ -31,6 +31,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/namespaces-only-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/namespaces-only-jsdoc/util.expected.async.js
@@ -30,6 +30,15 @@ const localeNamespaceLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (
+locale,
+	namespace?) => {
+	const loader = namespace
+		? localeNamespaceLoaders[locale][namespace]
+		: localeTranslationLoaders[locale];
+	return (await loader()).default;
+};
+
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
@@ -37,7 +46,7 @@ const updateDictionary = (locale, dictionary) =>
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
+		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
 	)
 	loadFormatters(locale)
 }
@@ -59,5 +68,5 @@ export const loadFormatters = (locale) =>
 export const loadNamespaceAsync = async (locale, namespace) =>
 	void updateDictionary(
 		locale,
-		/** @type { Partial<Translations> } */ (/** @type { unknown } */ ({ [namespace]: (await (localeNamespaceLoaders[locale][namespace])()).default }))
+		/** @type { Partial<Translations> } */ (/** @type { unknown } */ ({ [namespace]: (await importTranslations(locale, namespace))}))
 	)

--- a/packages/generator/test/generated/namespaces-only-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/namespaces-only-jsdoc/util.expected.async.js
@@ -58,6 +58,14 @@ export const loadFormatters = (locale) =>
 /**
  * @param { Locales } locale
  * @param { Namespaces } namespace
+ * @return { Promise<Translations[namespace]> }
+ */
+export const importNamespaceAsync = async(locale, namespace) =>
+	(await localeNamespaceLoaders[locale][namespace]()).default
+
+/**
+ * @param { Locales } locale
+ * @param { Namespaces } namespace
  * @return { Promise<void> }
  */
 export const loadNamespaceAsync = async (locale, namespace) =>
@@ -65,11 +73,3 @@ export const loadNamespaceAsync = async (locale, namespace) =>
 		locale,
 		/** @type { Partial<Translations> } */ ({ [namespace]: await importNamespaceAsync(locale, namespace)})
 	)
-
-/**
- * @param { Locales } locale
- * @param { Namespaces } namespace
- * @return { Promise<Partial<Translations>> }
- */
-export const importNamespaceAsync = async(locale, namespace) =>
-	(await localeNamespaceLoaders[locale][namespace]()).default;

--- a/packages/generator/test/generated/namespaces-only-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/namespaces-only-jsdoc/util.expected.async.js
@@ -30,14 +30,12 @@ const localeNamespaceLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (
-locale,
-	namespace?) => {
-	const loader = namespace
-		? localeNamespaceLoaders[locale][namespace]
-		: localeTranslationLoaders[locale];
-	return (await loader()).default;
-};
+/**
+ * @param { Locales } locale
+ * @return { Promise<Translations> }
+ */
+export const importLocaleAsync = async (locale) =>
+	(await localeTranslationLoaders[locale]()).default;
 
 /**
  * @param { Locales } locale
@@ -46,7 +44,7 @@ locale,
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
+		/** @type { Translations } */ (await importLocaleAsync(locale))
 	)
 	loadFormatters(locale)
 }
@@ -68,5 +66,13 @@ export const loadFormatters = (locale) =>
 export const loadNamespaceAsync = async (locale, namespace) =>
 	void updateDictionary(
 		locale,
-		/** @type { Partial<Translations> } */ (/** @type { unknown } */ ({ [namespace]: (await importTranslations(locale, namespace))}))
+		/** @type { Partial<Translations> } */ ({ [namespace]: await importNamespaceAsync(locale, namespace)})
 	)
+
+/**
+ * @param { Locales } locale
+ * @param { Namespaces } namespace
+ * @return { Promise<Partial<Translations>> }
+ */
+export const importNamespaceAsync = async(locale, namespace) =>
+	(await localeNamespaceLoaders[locale][namespace]()).default;

--- a/packages/generator/test/generated/namespaces-only-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/namespaces-only-jsdoc/util.expected.async.js
@@ -35,17 +35,14 @@ const updateDictionary = (locale, dictionary) =>
  * @return { Promise<Translations> }
  */
 export const importLocaleAsync = async (locale) =>
-	(await localeTranslationLoaders[locale]()).default;
+	/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
 
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
  */
 export const loadLocaleAsync = async (locale) => {
-	updateDictionary(
-		locale,
-		/** @type { Translations } */ (await importLocaleAsync(locale))
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/namespaces-only-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/namespaces-only-jsdoc/util.expected.async.js
@@ -69,7 +69,4 @@ export const importNamespaceAsync = async(locale, namespace) =>
  * @return { Promise<void> }
  */
 export const loadNamespaceAsync = async (locale, namespace) =>
-	void updateDictionary(
-		locale,
-		/** @type { Partial<Translations> } */ ({ [namespace]: await importNamespaceAsync(locale, namespace)})
-	)
+	void updateDictionary(locale, { [namespace]: await importNamespaceAsync(locale, namespace )})

--- a/packages/generator/test/generated/namespaces-only-jsdoc/util.expected.sync.js
+++ b/packages/generator/test/generated/namespaces-only-jsdoc/util.expected.sync.js
@@ -39,6 +39,5 @@ export const loadAllLocales = () => locales.forEach(loadLocale)
  * @param { Locales } locale
  * @return { void }
  */
-export const loadFormatters = (locale) => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale) =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/namespaces-only/util.expected.async.ts
+++ b/packages/generator/test/generated/namespaces-only/util.expected.async.ts
@@ -18,10 +18,19 @@ const localeNamespaceLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async <Namespace extends Namespaces>(
+locale: Locales,
+	namespace?: Namespace) => {
+	const loader = namespace
+		? localeNamespaceLoaders[locale][namespace]
+		: localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }
@@ -34,5 +43,5 @@ export const loadFormatters = (locale: Locales): void =>
 export const loadNamespaceAsync = async <Namespace extends Namespaces>(locale: Locales, namespace: Namespace): Promise<void> =>
 	void updateDictionary(
 		locale,
-		{ [namespace]: (await (localeNamespaceLoaders[locale][namespace])()).default } as unknown as Partial<Translations>
+		{ [namespace]: (await importTranslations(locale, namespace))} as Partial<Translations>
 	)

--- a/packages/generator/test/generated/namespaces-only/util.expected.async.ts
+++ b/packages/generator/test/generated/namespaces-only/util.expected.async.ts
@@ -35,7 +35,4 @@ export const importNamespaceAsync = async<Namespace extends Namespaces>(locale: 
 	(await localeNamespaceLoaders[locale][namespace]()).default as unknown as Translations[Namespace]
 
 export const loadNamespaceAsync = async <Namespace extends Namespaces>(locale: Locales, namespace: Namespace): Promise<void> =>
-	void updateDictionary(
-		locale,
-		{ [namespace]: await importNamespaceAsync(locale, namespace)}
-	)
+	void updateDictionary(locale, { [namespace]: await importNamespaceAsync(locale, namespace )})

--- a/packages/generator/test/generated/namespaces-only/util.expected.async.ts
+++ b/packages/generator/test/generated/namespaces-only/util.expected.async.ts
@@ -19,13 +19,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/namespaces-only/util.expected.async.ts
+++ b/packages/generator/test/generated/namespaces-only/util.expected.async.ts
@@ -31,11 +31,11 @@ export const loadAllLocalesAsync = (): Promise<void[]> => Promise.all(locales.ma
 export const loadFormatters = (locale: Locales): void =>
 	void (loadedFormatters[locale] = initFormatters(locale))
 
+export const importNamespaceAsync = async<Namespace extends Namespaces>(locale: Locales, namespace: Namespace) =>
+	(await localeNamespaceLoaders[locale][namespace]()).default as unknown as Translations[Namespace]
+
 export const loadNamespaceAsync = async <Namespace extends Namespaces>(locale: Locales, namespace: Namespace): Promise<void> =>
 	void updateDictionary(
 		locale,
 		{ [namespace]: await importNamespaceAsync(locale, namespace)}
 	)
-
-export const importNamespaceAsync = async<Namespace extends Namespaces>(locale: Locales, namespace: Namespace) =>
-	(await localeNamespaceLoaders[locale][namespace]()).default as unknown as Partial<Translations>;

--- a/packages/generator/test/generated/namespaces-only/util.expected.async.ts
+++ b/packages/generator/test/generated/namespaces-only/util.expected.async.ts
@@ -18,19 +18,13 @@ const localeNamespaceLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async <Namespace extends Namespaces>(
-locale: Locales,
-	namespace?: Namespace) => {
-	const loader = namespace
-		? localeNamespaceLoaders[locale][namespace]
-		: localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }
@@ -43,5 +37,8 @@ export const loadFormatters = (locale: Locales): void =>
 export const loadNamespaceAsync = async <Namespace extends Namespaces>(locale: Locales, namespace: Namespace): Promise<void> =>
 	void updateDictionary(
 		locale,
-		{ [namespace]: (await importTranslations(locale, namespace))} as Partial<Translations>
+		{ [namespace]: await importNamespaceAsync(locale, namespace)}
 	)
+
+export const importNamespaceAsync = async<Namespace extends Namespaces>(locale: Locales, namespace: Namespace) =>
+	(await localeNamespaceLoaders[locale][namespace]()).default as unknown as Partial<Translations>;

--- a/packages/generator/test/generated/namespaces-only/util.expected.sync.ts
+++ b/packages/generator/test/generated/namespaces-only/util.expected.sync.ts
@@ -25,6 +25,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/namespaces-with-locales-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/namespaces-with-locales-jsdoc/util.expected.async.js
@@ -51,17 +51,14 @@ const updateDictionary = (locale, dictionary) =>
  * @return { Promise<Translations> }
  */
 export const importLocaleAsync = async (locale) =>
-	(await localeTranslationLoaders[locale]()).default;
+	/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
 
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
  */
 export const loadLocaleAsync = async (locale) => {
-	updateDictionary(
-		locale,
-		/** @type { Translations } */ (await importLocaleAsync(locale))
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/namespaces-with-locales-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/namespaces-with-locales-jsdoc/util.expected.async.js
@@ -46,14 +46,12 @@ const localeNamespaceLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (
-locale,
-	namespace?) => {
-	const loader = namespace
-		? localeNamespaceLoaders[locale][namespace]
-		: localeTranslationLoaders[locale];
-	return (await loader()).default;
-};
+/**
+ * @param { Locales } locale
+ * @return { Promise<Translations> }
+ */
+export const importLocaleAsync = async (locale) =>
+	(await localeTranslationLoaders[locale]()).default;
 
 /**
  * @param { Locales } locale
@@ -62,7 +60,7 @@ locale,
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
+		/** @type { Translations } */ (await importLocaleAsync(locale))
 	)
 	loadFormatters(locale)
 }
@@ -84,5 +82,13 @@ export const loadFormatters = (locale) =>
 export const loadNamespaceAsync = async (locale, namespace) =>
 	void updateDictionary(
 		locale,
-		/** @type { Partial<Translations> } */ (/** @type { unknown } */ ({ [namespace]: (await importTranslations(locale, namespace))}))
+		/** @type { Partial<Translations> } */ ({ [namespace]: await importNamespaceAsync(locale, namespace)})
 	)
+
+/**
+ * @param { Locales } locale
+ * @param { Namespaces } namespace
+ * @return { Promise<Partial<Translations>> }
+ */
+export const importNamespaceAsync = async(locale, namespace) =>
+	(await localeNamespaceLoaders[locale][namespace]()).default;

--- a/packages/generator/test/generated/namespaces-with-locales-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/namespaces-with-locales-jsdoc/util.expected.async.js
@@ -46,6 +46,15 @@ const localeNamespaceLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (
+locale,
+	namespace?) => {
+	const loader = namespace
+		? localeNamespaceLoaders[locale][namespace]
+		: localeTranslationLoaders[locale];
+	return (await loader()).default;
+};
+
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
@@ -53,7 +62,7 @@ const updateDictionary = (locale, dictionary) =>
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
+		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
 	)
 	loadFormatters(locale)
 }
@@ -75,5 +84,5 @@ export const loadFormatters = (locale) =>
 export const loadNamespaceAsync = async (locale, namespace) =>
 	void updateDictionary(
 		locale,
-		/** @type { Partial<Translations> } */ (/** @type { unknown } */ ({ [namespace]: (await (localeNamespaceLoaders[locale][namespace])()).default }))
+		/** @type { Partial<Translations> } */ (/** @type { unknown } */ ({ [namespace]: (await importTranslations(locale, namespace))}))
 	)

--- a/packages/generator/test/generated/namespaces-with-locales-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/namespaces-with-locales-jsdoc/util.expected.async.js
@@ -85,7 +85,4 @@ export const importNamespaceAsync = async(locale, namespace) =>
  * @return { Promise<void> }
  */
 export const loadNamespaceAsync = async (locale, namespace) =>
-	void updateDictionary(
-		locale,
-		/** @type { Partial<Translations> } */ ({ [namespace]: await importNamespaceAsync(locale, namespace)})
-	)
+	void updateDictionary(locale, { [namespace]: await importNamespaceAsync(locale, namespace )})

--- a/packages/generator/test/generated/namespaces-with-locales-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/namespaces-with-locales-jsdoc/util.expected.async.js
@@ -74,6 +74,14 @@ export const loadFormatters = (locale) =>
 /**
  * @param { Locales } locale
  * @param { Namespaces } namespace
+ * @return { Promise<Translations[namespace]> }
+ */
+export const importNamespaceAsync = async(locale, namespace) =>
+	(await localeNamespaceLoaders[locale][namespace]()).default
+
+/**
+ * @param { Locales } locale
+ * @param { Namespaces } namespace
  * @return { Promise<void> }
  */
 export const loadNamespaceAsync = async (locale, namespace) =>
@@ -81,11 +89,3 @@ export const loadNamespaceAsync = async (locale, namespace) =>
 		locale,
 		/** @type { Partial<Translations> } */ ({ [namespace]: await importNamespaceAsync(locale, namespace)})
 	)
-
-/**
- * @param { Locales } locale
- * @param { Namespaces } namespace
- * @return { Promise<Partial<Translations>> }
- */
-export const importNamespaceAsync = async(locale, namespace) =>
-	(await localeNamespaceLoaders[locale][namespace]()).default;

--- a/packages/generator/test/generated/namespaces-with-locales-jsdoc/util.expected.sync.js
+++ b/packages/generator/test/generated/namespaces-with-locales-jsdoc/util.expected.sync.js
@@ -65,6 +65,5 @@ export const loadAllLocales = () => locales.forEach(loadLocale)
  * @param { Locales } locale
  * @return { void }
  */
-export const loadFormatters = (locale) => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale) =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/namespaces-with-locales/util.expected.async.ts
+++ b/packages/generator/test/generated/namespaces-with-locales/util.expected.async.ts
@@ -34,19 +34,13 @@ const localeNamespaceLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async <Namespace extends Namespaces>(
-locale: Locales,
-	namespace?: Namespace) => {
-	const loader = namespace
-		? localeNamespaceLoaders[locale][namespace]
-		: localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }
@@ -59,5 +53,8 @@ export const loadFormatters = (locale: Locales): void =>
 export const loadNamespaceAsync = async <Namespace extends Namespaces>(locale: Locales, namespace: Namespace): Promise<void> =>
 	void updateDictionary(
 		locale,
-		{ [namespace]: (await importTranslations(locale, namespace))} as Partial<Translations>
+		{ [namespace]: await importNamespaceAsync(locale, namespace)}
 	)
+
+export const importNamespaceAsync = async<Namespace extends Namespaces>(locale: Locales, namespace: Namespace) =>
+	(await localeNamespaceLoaders[locale][namespace]()).default as unknown as Partial<Translations>;

--- a/packages/generator/test/generated/namespaces-with-locales/util.expected.async.ts
+++ b/packages/generator/test/generated/namespaces-with-locales/util.expected.async.ts
@@ -47,11 +47,11 @@ export const loadAllLocalesAsync = (): Promise<void[]> => Promise.all(locales.ma
 export const loadFormatters = (locale: Locales): void =>
 	void (loadedFormatters[locale] = initFormatters(locale))
 
+export const importNamespaceAsync = async<Namespace extends Namespaces>(locale: Locales, namespace: Namespace) =>
+	(await localeNamespaceLoaders[locale][namespace]()).default as unknown as Translations[Namespace]
+
 export const loadNamespaceAsync = async <Namespace extends Namespaces>(locale: Locales, namespace: Namespace): Promise<void> =>
 	void updateDictionary(
 		locale,
 		{ [namespace]: await importNamespaceAsync(locale, namespace)}
 	)
-
-export const importNamespaceAsync = async<Namespace extends Namespaces>(locale: Locales, namespace: Namespace) =>
-	(await localeNamespaceLoaders[locale][namespace]()).default as unknown as Partial<Translations>;

--- a/packages/generator/test/generated/namespaces-with-locales/util.expected.async.ts
+++ b/packages/generator/test/generated/namespaces-with-locales/util.expected.async.ts
@@ -35,13 +35,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/namespaces-with-locales/util.expected.async.ts
+++ b/packages/generator/test/generated/namespaces-with-locales/util.expected.async.ts
@@ -51,7 +51,4 @@ export const importNamespaceAsync = async<Namespace extends Namespaces>(locale: 
 	(await localeNamespaceLoaders[locale][namespace]()).default as unknown as Translations[Namespace]
 
 export const loadNamespaceAsync = async <Namespace extends Namespaces>(locale: Locales, namespace: Namespace): Promise<void> =>
-	void updateDictionary(
-		locale,
-		{ [namespace]: await importNamespaceAsync(locale, namespace)}
-	)
+	void updateDictionary(locale, { [namespace]: await importNamespaceAsync(locale, namespace )})

--- a/packages/generator/test/generated/namespaces-with-locales/util.expected.async.ts
+++ b/packages/generator/test/generated/namespaces-with-locales/util.expected.async.ts
@@ -34,10 +34,19 @@ const localeNamespaceLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async <Namespace extends Namespaces>(
+locale: Locales,
+	namespace?: Namespace) => {
+	const loader = namespace
+		? localeNamespaceLoaders[locale][namespace]
+		: localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }
@@ -50,5 +59,5 @@ export const loadFormatters = (locale: Locales): void =>
 export const loadNamespaceAsync = async <Namespace extends Namespaces>(locale: Locales, namespace: Namespace): Promise<void> =>
 	void updateDictionary(
 		locale,
-		{ [namespace]: (await (localeNamespaceLoaders[locale][namespace])()).default } as unknown as Partial<Translations>
+		{ [namespace]: (await importTranslations(locale, namespace))} as Partial<Translations>
 	)

--- a/packages/generator/test/generated/namespaces-with-locales/util.expected.sync.ts
+++ b/packages/generator/test/generated/namespaces-with-locales/util.expected.sync.ts
@@ -51,6 +51,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/namespaces/util.expected.async.ts
+++ b/packages/generator/test/generated/namespaces/util.expected.async.ts
@@ -18,10 +18,19 @@ const localeNamespaceLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async <Namespace extends Namespaces>(
+locale: Locales,
+	namespace?: Namespace) => {
+	const loader = namespace
+		? localeNamespaceLoaders[locale][namespace]
+		: localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }
@@ -34,5 +43,5 @@ export const loadFormatters = (locale: Locales): void =>
 export const loadNamespaceAsync = async <Namespace extends Namespaces>(locale: Locales, namespace: Namespace): Promise<void> =>
 	void updateDictionary(
 		locale,
-		{ [namespace]: (await (localeNamespaceLoaders[locale][namespace])()).default } as unknown as Partial<Translations>
+		{ [namespace]: (await importTranslations(locale, namespace))} as Partial<Translations>
 	)

--- a/packages/generator/test/generated/namespaces/util.expected.async.ts
+++ b/packages/generator/test/generated/namespaces/util.expected.async.ts
@@ -35,7 +35,4 @@ export const importNamespaceAsync = async<Namespace extends Namespaces>(locale: 
 	(await localeNamespaceLoaders[locale][namespace]()).default as unknown as Translations[Namespace]
 
 export const loadNamespaceAsync = async <Namespace extends Namespaces>(locale: Locales, namespace: Namespace): Promise<void> =>
-	void updateDictionary(
-		locale,
-		{ [namespace]: await importNamespaceAsync(locale, namespace)}
-	)
+	void updateDictionary(locale, { [namespace]: await importNamespaceAsync(locale, namespace )})

--- a/packages/generator/test/generated/namespaces/util.expected.async.ts
+++ b/packages/generator/test/generated/namespaces/util.expected.async.ts
@@ -19,13 +19,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/namespaces/util.expected.async.ts
+++ b/packages/generator/test/generated/namespaces/util.expected.async.ts
@@ -31,11 +31,11 @@ export const loadAllLocalesAsync = (): Promise<void[]> => Promise.all(locales.ma
 export const loadFormatters = (locale: Locales): void =>
 	void (loadedFormatters[locale] = initFormatters(locale))
 
+export const importNamespaceAsync = async<Namespace extends Namespaces>(locale: Locales, namespace: Namespace) =>
+	(await localeNamespaceLoaders[locale][namespace]()).default as unknown as Translations[Namespace]
+
 export const loadNamespaceAsync = async <Namespace extends Namespaces>(locale: Locales, namespace: Namespace): Promise<void> =>
 	void updateDictionary(
 		locale,
 		{ [namespace]: await importNamespaceAsync(locale, namespace)}
 	)
-
-export const importNamespaceAsync = async<Namespace extends Namespaces>(locale: Locales, namespace: Namespace) =>
-	(await localeNamespaceLoaders[locale][namespace]()).default as unknown as Partial<Translations>;

--- a/packages/generator/test/generated/namespaces/util.expected.async.ts
+++ b/packages/generator/test/generated/namespaces/util.expected.async.ts
@@ -18,19 +18,13 @@ const localeNamespaceLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async <Namespace extends Namespaces>(
-locale: Locales,
-	namespace?: Namespace) => {
-	const loader = namespace
-		? localeNamespaceLoaders[locale][namespace]
-		: localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }
@@ -43,5 +37,8 @@ export const loadFormatters = (locale: Locales): void =>
 export const loadNamespaceAsync = async <Namespace extends Namespaces>(locale: Locales, namespace: Namespace): Promise<void> =>
 	void updateDictionary(
 		locale,
-		{ [namespace]: (await importTranslations(locale, namespace))} as Partial<Translations>
+		{ [namespace]: await importNamespaceAsync(locale, namespace)}
 	)
+
+export const importNamespaceAsync = async<Namespace extends Namespaces>(locale: Locales, namespace: Namespace) =>
+	(await localeNamespaceLoaders[locale][namespace]()).default as unknown as Partial<Translations>;

--- a/packages/generator/test/generated/namespaces/util.expected.sync.ts
+++ b/packages/generator/test/generated/namespaces/util.expected.sync.ts
@@ -25,6 +25,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/nested-deep/util.expected.async.ts
+++ b/packages/generator/test/generated/nested-deep/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/nested-deep/util.expected.async.ts
+++ b/packages/generator/test/generated/nested-deep/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/nested-deep/util.expected.async.ts
+++ b/packages/generator/test/generated/nested-deep/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/nested-deep/util.expected.sync.ts
+++ b/packages/generator/test/generated/nested-deep/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/nested-formatters/util.expected.async.ts
+++ b/packages/generator/test/generated/nested-formatters/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/nested-formatters/util.expected.async.ts
+++ b/packages/generator/test/generated/nested-formatters/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/nested-formatters/util.expected.async.ts
+++ b/packages/generator/test/generated/nested-formatters/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/nested-formatters/util.expected.sync.ts
+++ b/packages/generator/test/generated/nested-formatters/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/nested-with-arguments/util.expected.async.ts
+++ b/packages/generator/test/generated/nested-with-arguments/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/nested-with-arguments/util.expected.async.ts
+++ b/packages/generator/test/generated/nested-with-arguments/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/nested-with-arguments/util.expected.async.ts
+++ b/packages/generator/test/generated/nested-with-arguments/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/nested-with-arguments/util.expected.sync.ts
+++ b/packages/generator/test/generated/nested-with-arguments/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/only-plural-rules/util.expected.async.ts
+++ b/packages/generator/test/generated/only-plural-rules/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/only-plural-rules/util.expected.async.ts
+++ b/packages/generator/test/generated/only-plural-rules/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/only-plural-rules/util.expected.async.ts
+++ b/packages/generator/test/generated/only-plural-rules/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/only-plural-rules/util.expected.sync.ts
+++ b/packages/generator/test/generated/only-plural-rules/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/optional-parameters-esm/util.expected.async.js
+++ b/packages/generator/test/generated/optional-parameters-esm/util.expected.async.js
@@ -28,17 +28,14 @@ const updateDictionary = (locale, dictionary) =>
  * @return { Promise<Translations> }
  */
 export const importLocaleAsync = async (locale) =>
-	(await localeTranslationLoaders[locale]()).default;
+	/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
 
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
  */
 export const loadLocaleAsync = async (locale) => {
-	updateDictionary(
-		locale,
-		/** @type { Translations } */ (await importLocaleAsync(locale))
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/optional-parameters-esm/util.expected.async.js
+++ b/packages/generator/test/generated/optional-parameters-esm/util.expected.async.js
@@ -23,10 +23,12 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default;
-};
+/**
+ * @param { Locales } locale
+ * @return { Promise<Translations> }
+ */
+export const importLocaleAsync = async (locale) =>
+	(await localeTranslationLoaders[locale]()).default;
 
 /**
  * @param { Locales } locale
@@ -35,7 +37,7 @@ export const importTranslations = async (locale) => {
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
+		/** @type { Translations } */ (await importLocaleAsync(locale))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/optional-parameters-esm/util.expected.async.js
+++ b/packages/generator/test/generated/optional-parameters-esm/util.expected.async.js
@@ -23,6 +23,11 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default;
+};
+
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
@@ -30,7 +35,7 @@ const updateDictionary = (locale, dictionary) =>
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
+		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/optional-parameters-esm/util.expected.sync.js
+++ b/packages/generator/test/generated/optional-parameters-esm/util.expected.sync.js
@@ -34,6 +34,5 @@ export const loadAllLocales = () => locales.forEach(loadLocale)
  * @param { Locales } locale
  * @return { void }
  */
-export const loadFormatters = (locale) => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale) =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/optional-parameters/util.expected.async.ts
+++ b/packages/generator/test/generated/optional-parameters/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/optional-parameters/util.expected.async.ts
+++ b/packages/generator/test/generated/optional-parameters/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/optional-parameters/util.expected.async.ts
+++ b/packages/generator/test/generated/optional-parameters/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/optional-parameters/util.expected.sync.ts
+++ b/packages/generator/test/generated/optional-parameters/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/plural-part-before-key/util.expected.async.ts
+++ b/packages/generator/test/generated/plural-part-before-key/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/plural-part-before-key/util.expected.async.ts
+++ b/packages/generator/test/generated/plural-part-before-key/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/plural-part-before-key/util.expected.async.ts
+++ b/packages/generator/test/generated/plural-part-before-key/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/plural-part-before-key/util.expected.sync.ts
+++ b/packages/generator/test/generated/plural-part-before-key/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/plural-part-without-output/util.expected.async.ts
+++ b/packages/generator/test/generated/plural-part-without-output/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/plural-part-without-output/util.expected.async.ts
+++ b/packages/generator/test/generated/plural-part-without-output/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/plural-part-without-output/util.expected.async.ts
+++ b/packages/generator/test/generated/plural-part-without-output/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/plural-part-without-output/util.expected.sync.ts
+++ b/packages/generator/test/generated/plural-part-without-output/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/same-keyed-param/util.expected.async.ts
+++ b/packages/generator/test/generated/same-keyed-param/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/same-keyed-param/util.expected.async.ts
+++ b/packages/generator/test/generated/same-keyed-param/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/same-keyed-param/util.expected.async.ts
+++ b/packages/generator/test/generated/same-keyed-param/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/same-keyed-param/util.expected.sync.ts
+++ b/packages/generator/test/generated/same-keyed-param/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/same-param/util.expected.async.ts
+++ b/packages/generator/test/generated/same-param/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/same-param/util.expected.async.ts
+++ b/packages/generator/test/generated/same-param/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/same-param/util.expected.async.ts
+++ b/packages/generator/test/generated/same-param/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/same-param/util.expected.sync.ts
+++ b/packages/generator/test/generated/same-param/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/simple/util.expected.async.ts
+++ b/packages/generator/test/generated/simple/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/simple/util.expected.async.ts
+++ b/packages/generator/test/generated/simple/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/simple/util.expected.async.ts
+++ b/packages/generator/test/generated/simple/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/simple/util.expected.sync.ts
+++ b/packages/generator/test/generated/simple/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/special-chars/util.expected.async.ts
+++ b/packages/generator/test/generated/special-chars/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/special-chars/util.expected.async.ts
+++ b/packages/generator/test/generated/special-chars/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/special-chars/util.expected.async.ts
+++ b/packages/generator/test/generated/special-chars/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/special-chars/util.expected.sync.ts
+++ b/packages/generator/test/generated/special-chars/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/switch-case/util.expected.async.ts
+++ b/packages/generator/test/generated/switch-case/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/switch-case/util.expected.async.ts
+++ b/packages/generator/test/generated/switch-case/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/switch-case/util.expected.async.ts
+++ b/packages/generator/test/generated/switch-case/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/switch-case/util.expected.sync.ts
+++ b/packages/generator/test/generated/switch-case/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/typescript-3.0-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/typescript-3.0-jsdoc/util.expected.async.js
@@ -28,17 +28,14 @@ const updateDictionary = (locale, dictionary) =>
  * @return { Promise<Translations> }
  */
 export const importLocaleAsync = async (locale) =>
-	(await localeTranslationLoaders[locale]()).default;
+	/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
 
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
  */
 export const loadLocaleAsync = async (locale) => {
-	updateDictionary(
-		locale,
-		/** @type { Translations } */ (await importLocaleAsync(locale))
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/typescript-3.0-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/typescript-3.0-jsdoc/util.expected.async.js
@@ -23,10 +23,12 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default;
-};
+/**
+ * @param { Locales } locale
+ * @return { Promise<Translations> }
+ */
+export const importLocaleAsync = async (locale) =>
+	(await localeTranslationLoaders[locale]()).default;
 
 /**
  * @param { Locales } locale
@@ -35,7 +37,7 @@ export const importTranslations = async (locale) => {
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
+		/** @type { Translations } */ (await importLocaleAsync(locale))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/typescript-3.0-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/typescript-3.0-jsdoc/util.expected.async.js
@@ -23,6 +23,11 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default;
+};
+
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
@@ -30,7 +35,7 @@ const updateDictionary = (locale, dictionary) =>
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
+		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/typescript-3.0-jsdoc/util.expected.sync.js
+++ b/packages/generator/test/generated/typescript-3.0-jsdoc/util.expected.sync.js
@@ -34,6 +34,5 @@ export const loadAllLocales = () => locales.forEach(loadLocale)
  * @param { Locales } locale
  * @return { void }
  */
-export const loadFormatters = (locale) => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale) =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/typescript-3.0/util.expected.async.ts
+++ b/packages/generator/test/generated/typescript-3.0/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/typescript-3.0/util.expected.async.ts
+++ b/packages/generator/test/generated/typescript-3.0/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/typescript-3.0/util.expected.async.ts
+++ b/packages/generator/test/generated/typescript-3.0/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/typescript-3.0/util.expected.sync.ts
+++ b/packages/generator/test/generated/typescript-3.0/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/typescript-3.8-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/typescript-3.8-jsdoc/util.expected.async.js
@@ -28,17 +28,14 @@ const updateDictionary = (locale, dictionary) =>
  * @return { Promise<Translations> }
  */
 export const importLocaleAsync = async (locale) =>
-	(await localeTranslationLoaders[locale]()).default;
+	/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
 
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
  */
 export const loadLocaleAsync = async (locale) => {
-	updateDictionary(
-		locale,
-		/** @type { Translations } */ (await importLocaleAsync(locale))
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/typescript-3.8-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/typescript-3.8-jsdoc/util.expected.async.js
@@ -23,10 +23,12 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default;
-};
+/**
+ * @param { Locales } locale
+ * @return { Promise<Translations> }
+ */
+export const importLocaleAsync = async (locale) =>
+	(await localeTranslationLoaders[locale]()).default;
 
 /**
  * @param { Locales } locale
@@ -35,7 +37,7 @@ export const importTranslations = async (locale) => {
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
+		/** @type { Translations } */ (await importLocaleAsync(locale))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/typescript-3.8-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/typescript-3.8-jsdoc/util.expected.async.js
@@ -23,6 +23,11 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default;
+};
+
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
@@ -30,7 +35,7 @@ const updateDictionary = (locale, dictionary) =>
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
+		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/typescript-3.8-jsdoc/util.expected.sync.js
+++ b/packages/generator/test/generated/typescript-3.8-jsdoc/util.expected.sync.js
@@ -34,6 +34,5 @@ export const loadAllLocales = () => locales.forEach(loadLocale)
  * @param { Locales } locale
  * @return { void }
  */
-export const loadFormatters = (locale) => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale) =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/typescript-3.8/util.expected.async.ts
+++ b/packages/generator/test/generated/typescript-3.8/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/typescript-3.8/util.expected.async.ts
+++ b/packages/generator/test/generated/typescript-3.8/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/typescript-3.8/util.expected.async.ts
+++ b/packages/generator/test/generated/typescript-3.8/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/typescript-3.8/util.expected.sync.ts
+++ b/packages/generator/test/generated/typescript-3.8/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/typescript-4.1-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/typescript-4.1-jsdoc/util.expected.async.js
@@ -28,17 +28,14 @@ const updateDictionary = (locale, dictionary) =>
  * @return { Promise<Translations> }
  */
 export const importLocaleAsync = async (locale) =>
-	(await localeTranslationLoaders[locale]()).default;
+	/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
 
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
  */
 export const loadLocaleAsync = async (locale) => {
-	updateDictionary(
-		locale,
-		/** @type { Translations } */ (await importLocaleAsync(locale))
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/typescript-4.1-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/typescript-4.1-jsdoc/util.expected.async.js
@@ -23,10 +23,12 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default;
-};
+/**
+ * @param { Locales } locale
+ * @return { Promise<Translations> }
+ */
+export const importLocaleAsync = async (locale) =>
+	(await localeTranslationLoaders[locale]()).default;
 
 /**
  * @param { Locales } locale
@@ -35,7 +37,7 @@ export const importTranslations = async (locale) => {
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
+		/** @type { Translations } */ (await importLocaleAsync(locale))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/typescript-4.1-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/typescript-4.1-jsdoc/util.expected.async.js
@@ -23,6 +23,11 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default;
+};
+
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
@@ -30,7 +35,7 @@ const updateDictionary = (locale, dictionary) =>
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
+		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/typescript-4.1-jsdoc/util.expected.sync.js
+++ b/packages/generator/test/generated/typescript-4.1-jsdoc/util.expected.sync.js
@@ -34,6 +34,5 @@ export const loadAllLocales = () => locales.forEach(loadLocale)
  * @param { Locales } locale
  * @return { void }
  */
-export const loadFormatters = (locale) => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale) =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/typescript-4.1/util.expected.async.ts
+++ b/packages/generator/test/generated/typescript-4.1/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/typescript-4.1/util.expected.async.ts
+++ b/packages/generator/test/generated/typescript-4.1/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/typescript-4.1/util.expected.async.ts
+++ b/packages/generator/test/generated/typescript-4.1/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/typescript-4.1/util.expected.sync.ts
+++ b/packages/generator/test/generated/typescript-4.1/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/update.ts
+++ b/packages/generator/test/generated/update.ts
@@ -1,17 +1,21 @@
 // this file will replace all the expected.js files with their _actual equivalents
 
 import { readFileSync, writeFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname } from 'path'
 import glob from 'tiny-glob/sync.js'
 
 console.log(`
 updating generated files ...`
 )
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const cwd = typeof __dirname !== 'undefined'
+  ? __dirname
+  : dirname(fileURLToPath(import.meta.url))
 
-glob('**/*.actual.*', { cwd: __dirname }).forEach((file) => {
-	const actual = readFileSync(`${__dirname}/${file}`, 'utf-8')
-	writeFileSync(`${__dirname}/${file.replace('.actual.', '.expected.')}`, actual)
+glob('**/*.actual.*', { cwd }).forEach((file) => {
+	const actual = readFileSync(`${cwd}/${file}`, 'utf-8')
+	writeFileSync(`${cwd}/${file.replace('.actual.', '.expected.')}`, actual)
 })
 
 console.log('... completed')

--- a/packages/generator/test/generated/update.ts
+++ b/packages/generator/test/generated/update.ts
@@ -7,6 +7,8 @@ console.log(`
 updating generated files ...`
 )
 
+const __dirname = new URL('.', import.meta.url).pathname;
+
 glob('**/*.actual.*', { cwd: __dirname }).forEach((file) => {
 	const actual = readFileSync(`${__dirname}/${file}`, 'utf-8')
 	writeFileSync(`${__dirname}/${file.replace('.actual.', '.expected.')}`, actual)

--- a/packages/generator/test/generated/update.ts
+++ b/packages/generator/test/generated/update.ts
@@ -1,21 +1,21 @@
 // this file will replace all the expected.js files with their _actual equivalents
 
 import { readFileSync, writeFileSync } from 'fs'
-import { fileURLToPath } from 'url'
 import { dirname } from 'path'
 import glob from 'tiny-glob/sync.js'
+import { fileURLToPath } from 'url'
+
+//@ts-ignore
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
 
 console.log(`
 updating generated files ...`
 )
 
-const cwd = typeof __dirname !== 'undefined'
-  ? __dirname
-  : dirname(fileURLToPath(import.meta.url))
-
-glob('**/*.actual.*', { cwd }).forEach((file) => {
-	const actual = readFileSync(`${cwd}/${file}`, 'utf-8')
-	writeFileSync(`${cwd}/${file.replace('.actual.', '.expected.')}`, actual)
+glob('**/*.actual.*', { cwd: __dirname }).forEach((file) => {
+	const actual = readFileSync(`${__dirname}/${file}`, 'utf-8')
+	writeFileSync(`${__dirname}/${file.replace('.actual.', '.expected.')}`, actual)
 })
 
 console.log('... completed')

--- a/packages/generator/test/generated/with-formatters-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/with-formatters-jsdoc/util.expected.async.js
@@ -28,17 +28,14 @@ const updateDictionary = (locale, dictionary) =>
  * @return { Promise<Translations> }
  */
 export const importLocaleAsync = async (locale) =>
-	(await localeTranslationLoaders[locale]()).default;
+	/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
 
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
  */
 export const loadLocaleAsync = async (locale) => {
-	updateDictionary(
-		locale,
-		/** @type { Translations } */ (await importLocaleAsync(locale))
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/with-formatters-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/with-formatters-jsdoc/util.expected.async.js
@@ -23,10 +23,12 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default;
-};
+/**
+ * @param { Locales } locale
+ * @return { Promise<Translations> }
+ */
+export const importLocaleAsync = async (locale) =>
+	(await localeTranslationLoaders[locale]()).default;
 
 /**
  * @param { Locales } locale
@@ -35,7 +37,7 @@ export const importTranslations = async (locale) => {
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
+		/** @type { Translations } */ (await importLocaleAsync(locale))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/with-formatters-jsdoc/util.expected.async.js
+++ b/packages/generator/test/generated/with-formatters-jsdoc/util.expected.async.js
@@ -23,6 +23,11 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale, dictionary) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default;
+};
+
 /**
  * @param { Locales } locale
  * @return { Promise<void> }
@@ -30,7 +35,7 @@ const updateDictionary = (locale, dictionary) =>
 export const loadLocaleAsync = async (locale) => {
 	updateDictionary(
 		locale,
-		/** @type { Translations } */ (/** @type { unknown } */ ((await localeTranslationLoaders[locale]()).default))
+		/** @type { Translations } */ (/** @type { unknown } */ ((await importTranslations(locale))))
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/with-formatters-jsdoc/util.expected.sync.js
+++ b/packages/generator/test/generated/with-formatters-jsdoc/util.expected.sync.js
@@ -34,6 +34,5 @@ export const loadAllLocales = () => locales.forEach(loadLocale)
  * @param { Locales } locale
  * @return { void }
  */
-export const loadFormatters = (locale) => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale) =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/with-formatters/util.expected.async.ts
+++ b/packages/generator/test/generated/with-formatters/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/with-formatters/util.expected.async.ts
+++ b/packages/generator/test/generated/with-formatters/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/with-formatters/util.expected.async.ts
+++ b/packages/generator/test/generated/with-formatters/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/with-formatters/util.expected.sync.ts
+++ b/packages/generator/test/generated/with-formatters/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))

--- a/packages/generator/test/generated/with-params/util.expected.async.ts
+++ b/packages/generator/test/generated/with-params/util.expected.async.ts
@@ -12,10 +12,15 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
+export const importTranslations = async (locale: Locales) => {
+	const loader = localeTranslationLoaders[locale];
+	return (await loader()).default as unknown;
+};
+
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await localeTranslationLoaders[locale]()).default as unknown as Translations
+		(await importTranslations(locale)) as Translations
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/with-params/util.expected.async.ts
+++ b/packages/generator/test/generated/with-params/util.expected.async.ts
@@ -12,15 +12,13 @@ const localeTranslationLoaders = {
 const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
-export const importTranslations = async (locale: Locales) => {
-	const loader = localeTranslationLoaders[locale];
-	return (await loader()).default as unknown;
-};
+export const importLocaleAsync = async (locale: Locales) =>
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
 	updateDictionary(
 		locale,
-		(await importTranslations(locale)) as Translations
+		await importLocaleAsync(locale)
 	)
 	loadFormatters(locale)
 }

--- a/packages/generator/test/generated/with-params/util.expected.async.ts
+++ b/packages/generator/test/generated/with-params/util.expected.async.ts
@@ -13,13 +13,10 @@ const updateDictionary = (locale: Locales, dictionary: Partial<Translations>) =>
 	loadedLocales[locale] = { ...loadedLocales[locale], ...dictionary }
 
 export const importLocaleAsync = async (locale: Locales) =>
-	(await localeTranslationLoaders[locale]()).default as unknown as Translations;
+	(await localeTranslationLoaders[locale]()).default as unknown as Translations
 
 export const loadLocaleAsync = async (locale: Locales): Promise<void> => {
-	updateDictionary(
-		locale,
-		await importLocaleAsync(locale)
-	)
+	updateDictionary(locale, await importLocaleAsync(locale))
 	loadFormatters(locale)
 }
 

--- a/packages/generator/test/generated/with-params/util.expected.sync.ts
+++ b/packages/generator/test/generated/with-params/util.expected.sync.ts
@@ -20,6 +20,5 @@ export const loadLocale = (locale: Locales): void => {
 
 export const loadAllLocales = (): void => locales.forEach(loadLocale)
 
-export const loadFormatters = (locale: Locales): void => {
-	loadedFormatters[locale] = initFormatters(locale)
-}
+export const loadFormatters = (locale: Locales): void =>
+	void (loadedFormatters[locale] = initFormatters(locale))


### PR DESCRIPTION
For a background discussion, see this thread:

https://github.com/ivanhofer/typesafe-i18n/discussions/384

Basically this PR refactors the translation importing into separate functions. These function are also exported where they can be used in situations where you want to import translations without loading them into the global translations dictionary (`loadedLocales`).

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

