### PR TITLE
fix: link correct types for React adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # Version 5
 
+## 5.10.1 (2022-07-25)
+
+Fix:
+ - link correct types for React adapter
+
 ## 5.10.0 (2022-07-25)
 
 Feature:

--- a/packages/link-typedefinitions.ts
+++ b/packages/link-typedefinitions.ts
@@ -40,11 +40,14 @@ mappings.forEach(([fromWheretoImport, outputPath = fromWheretoImport, filterFunc
 	const filteredFiles = (filterFunction && files.filter(filterFunction)) || files
 
 	filteredFiles.forEach((file) => {
-		const fileName = file.substring(0, file.length - 6)
+		const esm = file.endsWith('.d.mts')
+		const fileName = file.replace(esm ? '.d.mts' : '.d.ts', '')
 
 		writeFileSync(
 			resolve(__dirname, `../${outputPath}/${file.replace('.d.mts', '.d.ts')}`),
-			`export * from '${goToRoot(outputPath, file)}types/${fromWheretoImport}/src/${fileName}.mjs'`,
+			`export * from '${goToRoot(outputPath, file)}types/${fromWheretoImport}/src/${fileName}.${
+				esm ? 'mjs' : 'js'
+			}'`,
 			{ encoding: 'utf8' },
 		)
 	})


### PR DESCRIPTION
Unlike other packages, react entry file is `index.tsx` (not `index.mts`). Therefore, the type file created by `tsc` will be `index.d.ts` instead of `index.d.mts`.
I fixed to handle `.d.ts` files correctly in the process of link type definitions.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

## generator

If you change something in the `generator`, please also:
 - add some snapshot tests to the `packages/generator/test/generator.test.ts`-file
 - then run `pnpm test` => you should see your tests failing
 - run `pnpm test:update-generated-files`
 - again run `pnpm test` => your tests should pass
 - then add all the created `*.expected.*`-files to the git-index and
 - make sure these files look like you would expect them
 - finally commit these files to the repository