### PR TITLE
chore: fix typo in generated file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ You can use `typesafe-i18n` in a variety of project-setups:
 
 ### Other frameworks
 
-All you need is inside the [generated](https://github.com/ivanhofer/typesafe-i18n/tree/main/packages/generator#folder-structure) file `i18n-utils.ts`. You can use the functions in there to create a small wrapper for your application.
+All you need is inside the [generated](https://github.com/ivanhofer/typesafe-i18n/tree/main/packages/generator#folder-structure) file `i18n-util.ts`. You can use the functions in there to create a small wrapper for your application.
 
 > Feel free to open a new [discussion](https://github.com/ivanhofer/typesafe-i18n/discussions) if you need a guide for a specific framework.
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -440,7 +440,7 @@ The `typesafeI18nString` and `typesafeI18nObject` functions offer full typesafet
 
 ### more typesafety features
 
-In order to get full typechecking support, you should use the exported functions in `i18n-utils.ts` created by the [generator](https://github.com/ivanhofer/typesafe-i18n/tree/main/packages/generator#generator). It contains fully typed wrappers for the following core functionalities.
+In order to get full typechecking support, you should use the exported functions in `i18n-util.ts` created by the [generator](https://github.com/ivanhofer/typesafe-i18n/tree/main/packages/generator#generator). It contains fully typed wrappers for the following core functionalities.
 
 
 <!-- ------------------------------------------------------------------------------------------ -->


### PR DESCRIPTION
Minor fix in README for the generated file name `i18n-util.ts`.