### PR TITLE
chore: Fix typo in generator documentation

### DIFF
--- a/packages/generator/README.md
+++ b/packages/generator/README.md
@@ -104,7 +104,7 @@ src/
  - `i18n-util.async.ts`\
    This file contains the logic to load individual locales asynchronously.
 
- - `i18n-util.ts`\
+ - `i18n-util.sync.ts`\
    This file contains the logic to load your locales in a synchronous way.
 
  - `i18n-util.ts`\


### PR DESCRIPTION
In the section of `generator` documentation which explains which files are automatically generated, `i18n-util.sync.ts` is incorrectly referred to as `i18n-util.ts`. This change fixes the typo.