### PR TITLE
docs: added more comprehensive react example

### DIFF
--- a/packages/adapter-react/README.md
+++ b/packages/adapter-react/README.md
@@ -53,17 +53,38 @@ The generator will create a custom React component and context inside `i18n-reac
 Wrap your application root with the `TypesafeI18n` component:
 
 ```jsx
-import React from 'react'
+import React, { useState, useEffect } from 'react'
+import { detectLocale, navigatorDetector } from 'typesafe-i18n/detectors';
 import TypesafeI18n from './i18n/i18n-react'
+import { baseLocale, locales } from 'i18n/i18n-util';
+import { loadLocale } from './i18n/i18n-util.sync';
+
 
 function App() {
+   // Detect locale
+   // (Use as advanaced locale detection strategy as you like. 
+   // More info: https://github.com/ivanhofer/typesafe-i18n/tree/main/packages/detectors)
+   const locale = detectLocale(
+    baseLocale,
+    locales,
+    navigatorDetector
+  );
 
-   // TODO: load locales (https://github.com/ivanhofer/typesafe-i18n/tree/main/packages/generator#loading-locales)
-
+   // Load locales
+   // (Use a data fetching solution that you prefer)
+   const [localesLoaded, setLocalesLoaded] = useState(false);
+   useEffect(() => {
+      loadLocale(locale).then(() => setLocalesLoaded(true))
+   }, [locale])
+   
+   if(!localesLoaded) {
+      return null;
+   }
+   
    return (
-      <TypesafeI18n locale="en">
+      <TypesafeI18n locale={locale}>
 
-         <!-- your app goes here -->
+         {/* Your app goes here */} 
 
       </TypesafeI18n>
    )

--- a/packages/adapter-react/README.md
+++ b/packages/adapter-react/README.md
@@ -54,9 +54,9 @@ Wrap your application root with the `TypesafeI18n` component:
 
 ```jsx
 import React, { useState, useEffect } from 'react'
-import { detectLocale, navigatorDetector } from 'typesafe-i18n/detectors'
+import { navigatorDetector } from 'typesafe-i18n/detectors'
 import TypesafeI18n from './i18n/i18n-react'
-import { baseLocale, locales } from 'i18n/i18n-util'
+import { detectLocale } from './i18n/i18n-util'
 import { loadLocale } from './i18n/i18n-util.sync'
 
 
@@ -64,11 +64,7 @@ function App() {
    // Detect locale
    // (Use as advanaced locale detection strategy as you like. 
    // More info: https://github.com/ivanhofer/typesafe-i18n/tree/main/packages/detectors)
-   const locale = detectLocale(
-    baseLocale,
-    locales,
-    navigatorDetector
-  )
+   const locale = detectLocale(navigatorDetector)
 
    // Load locales
    // (Use a data fetching solution that you prefer)

--- a/packages/adapter-react/README.md
+++ b/packages/adapter-react/README.md
@@ -54,10 +54,10 @@ Wrap your application root with the `TypesafeI18n` component:
 
 ```jsx
 import React, { useState, useEffect } from 'react'
-import { detectLocale, navigatorDetector } from 'typesafe-i18n/detectors';
+import { detectLocale, navigatorDetector } from 'typesafe-i18n/detectors'
 import TypesafeI18n from './i18n/i18n-react'
-import { baseLocale, locales } from 'i18n/i18n-util';
-import { loadLocale } from './i18n/i18n-util.sync';
+import { baseLocale, locales } from 'i18n/i18n-util'
+import { loadLocale } from './i18n/i18n-util.sync'
 
 
 function App() {
@@ -68,17 +68,17 @@ function App() {
     baseLocale,
     locales,
     navigatorDetector
-  );
+  )
 
    // Load locales
    // (Use a data fetching solution that you prefer)
-   const [localesLoaded, setLocalesLoaded] = useState(false);
+   const [localesLoaded, setLocalesLoaded] = useState(false)
    useEffect(() => {
       loadLocale(locale).then(() => setLocalesLoaded(true))
    }, [locale])
    
    if(!localesLoaded) {
-      return null;
+      return null
    }
    
    return (

--- a/packages/adapter-react/README.md
+++ b/packages/adapter-react/README.md
@@ -53,7 +53,7 @@ The generator will create a custom React component and context inside `i18n-reac
 Wrap your application root with the `TypesafeI18n` component:
 
 ```jsx
-import React, { useState, useEffect } from 'react'
+import { useState, useEffect } from 'react'
 import { navigatorDetector } from 'typesafe-i18n/detectors'
 import TypesafeI18n from './i18n/i18n-react'
 import { detectLocale } from './i18n/i18n-util'
@@ -92,7 +92,6 @@ export default App
 That's it. You can then start using `typesafe-i18n` inside your React components.
 
 ```jsx
-import React from 'react'
 import { useI18nContext } from './i18n/i18n-react'
 
 function Greeting(props) {
@@ -116,7 +115,6 @@ export default Greeting
 When running the [generator](https://github.com/ivanhofer/typesafe-i18n/tree/main/packages/generator#generator), the file `i18n-react.tsx` will export a React component you can wrap around your application. It requires the prop `locale` where you need to pass a locale to initialize the context.
 
 ```jsx
-import React from 'react'
 import TypesafeI18n from './i18n/i18n-react'
 
 function App() {
@@ -141,7 +139,6 @@ export default App
 Also a React context is exported by the generated file `i18n-react.tsx`. You can use it with the `useI18nContext` function.
 
 ```jsx
-import React from 'react'
 import { useI18nContext } from './i18n/i18n-react'
 
 function MyComponent(props) {
@@ -160,7 +157,6 @@ The context gives you access to following variables:
 An initialized [`i18nObject`](https://github.com/ivanhofer/typesafe-i18n/tree/main/packages/runtime#i18nObject) you can use to translate your app.
 
 ```jsx
-import React from 'react'
 import { useI18nContext } from './i18n/i18n-react'
 
 function ProjectOverview() {
@@ -182,7 +178,6 @@ A function to set another locale for the context.
 
 
 ```jsx
-import React from 'react'
 import { useI18nContext } from './i18n/i18n-react'
 
 function LanguageSelection() {


### PR DESCRIPTION
Currently, it's really easy to miss single line comment `// TODO: load locales` in the react example. This PR adds a basic example of detecting and loading locales in a standard react app.