### PR TITLE
fix: adjust regex that parses package.json scripts for #631

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # Version 5
 
+## 5.24.3 (2023-03-26)
+
+Fix:
+ - correctly inject `typesafe-i18n` script in `package.json` if block contains brackets [#632](https://github.com/ivanhofer/typesafe-i18n/pull/632)
+
 ## 5.24.2 (2023-03-02)
 
 Fix:

--- a/packages/cli/src/setup/runtimes/node.mts
+++ b/packages/cli/src/setup/runtimes/node.mts
@@ -84,7 +84,7 @@ const installDependencies = async () => {
 // --------------------------------------------------------------------------------------------------------------------
 
 // detects the amount of whitespace before and after the current scripts
-const REGEX_DETECT_SCRIPT_SECTION = /"scripts":\s*{(?<begin>\s*)("([^"]|\\")*":\s*"([^"]|\\")*"(,\s*)?)*(?<end>\s+)}/gm
+const REGEX_DETECT_SCRIPT_SECTION = /"scripts":\s*{(?<begin>\s*)(".*(?<!\\)":\s*".*(?<!\\)"(,\s*)?)*(?<end>\s+)}/gm
 
 // TODO: use `npm add script` command (only works with npm > 7)
 // https://docs.npmjs.com/cli/v7/commands/npm-set-script


### PR DESCRIPTION
A small fix for `--setup-auto` mangling some script entries as per #631.

Modifies the approach the regex uses to avoid matching `\"`, switching to utilise negative lookbehind instead.

I'm not sure how to fully test this change as there appear to be no tests for the CLI. I tested manually in a basic case and in the previously failing case. Please don't take my word for it, however!

Apologies, but this PR was hasily created within GitHub itself after testing the hack within my own node_modules. Branch name is scuffed and there could possibly be whitespace issues.

Fixes #631.