### PR TITLE
feat: add possibility to override default path to config file

### DIFF
--- a/packages/cli/src/cli.mts
+++ b/packages/cli/src/cli.mts
@@ -13,6 +13,7 @@ program.description('CLI to read the base translation file and generate types')
 program.option('--no-watch', 'run the generator only once (CI)')
 program.option('--setup', 'step-by-step setup')
 program.option('--setup-auto', 'auto-guess setup')
+program.option('-p, --project <path>', 'generate translations by configuration file')
 
 program.version(version)
 
@@ -22,12 +23,12 @@ const run = async () => {
 
 	logger.info(`version ${version}`)
 
-	await checkAndUpdateSchemaVersion()
+	await checkAndUpdateSchemaVersion(options.project)
 
 	if (options.setup || options.setupAuto) {
 		await setup(options.setupAuto)
 	} else {
-		startGenerator(undefined, options['watch'])
+		startGenerator(options.project || '.typesafe-i18n.json', options['watch'])
 	}
 }
 

--- a/packages/config/src/config.mts
+++ b/packages/config/src/config.mts
@@ -10,11 +10,11 @@ export const writeConfigToFile = async (config: GeneratorConfig) =>
 
 export const doesConfigFileExist = async () => doesPathExist(resolve('.typesafe-i18n.json'))
 
-export const readRawConfig = async () =>
-	(await importFile<GeneratorConfig & { $schema?: string }>(resolve('.typesafe-i18n.json'), false)) || {}
+export const readRawConfig = async (configPath: string) =>
+	(await importFile<GeneratorConfig & { $schema?: string }>(resolve(configPath), false)) || {}
 
-export const readConfig = async (): Promise<GeneratorConfig> => {
-	const generatorConfig = await readRawConfig()
+export const readConfig = async (configPath = '.typesafe-i18n.json'): Promise<GeneratorConfig> => {
+	const generatorConfig = await readRawConfig(configPath)
 
 	// remove "$schema" property
 	const configWithoutSchemaAttribute = Object.fromEntries(

--- a/packages/config/src/core.mts
+++ b/packages/config/src/core.mts
@@ -23,22 +23,22 @@ export const applyDefaultValues = async (
 	...(config as unknown as any),
 })
 
-const readConfigFromDisk = async (fs: FileSystemUtil) => {
-	const content = await fs.readFile('.typesafe-i18n.json').catch(() => '{}')
+const readConfigFromDisk = async (fs: FileSystemUtil, configPath: string) => {
+	const content = await fs.readFile(configPath).catch(() => '{}')
 
 	return JSON.parse(content.toString()) as GeneratorConfig & { $schema?: string }
 }
 
-export const getConfig = async (fs: FileSystemUtil) => {
-	const config = await readConfigFromDisk(fs)
+export const getConfig = async (fs: FileSystemUtil, configPath = '.typesafe-i18n.json') => {
+	const config = await readConfigFromDisk(fs, configPath)
 
 	return applyDefaultValues(config)
 }
 
 // --------------------------------------------------------------------------------------------------------------------
 
-export const getLocaleInformation = async (fs: FileSystemUtil) => {
-	const config = await getConfig(fs)
+export const getLocaleInformation = async (fs: FileSystemUtil, configPath = '.typesafe-i18n.json') => {
+	const config = await getConfig(fs, configPath)
 
 	return {
 		base: config.baseLocale,

--- a/packages/config/src/update-schema-version.mts
+++ b/packages/config/src/update-schema-version.mts
@@ -2,8 +2,8 @@ import { logger } from '../../generator/src/utils/logger.mjs'
 import { version } from '../../version'
 import { readRawConfig, writeConfigToFile } from './config.mjs'
 
-export const checkAndUpdateSchemaVersion = async () => {
-	const config = await readRawConfig()
+export const checkAndUpdateSchemaVersion = async (configPath = '.typesafe-i18n.json') => {
+	const config = await readRawConfig(configPath)
 
 	if (!config.$schema) return
 
@@ -11,5 +11,5 @@ export const checkAndUpdateSchemaVersion = async () => {
 
 	await writeConfigToFile(config)
 
-	logger.info(`updated '$schema' version of '.typesafe-i18n.json' to '${version}'`)
+	logger.info(`updated '$schema' version of '${configPath}' to '${version}'`)
 }

--- a/packages/generator/src/generator.mts
+++ b/packages/generator/src/generator.mts
@@ -99,12 +99,11 @@ const debounce = (callback: () => void) =>
 		++debounceCounter,
 	)
 
-export const startGenerator = async (config?: GeneratorConfig, watchFiles = true): Promise<void> => {
+export const startGenerator = async (configPath: string, watchFiles = true): Promise<void> => {
 	logger = createLogger(console, !watchFiles)
 
 	const parsedConfig = {
-		...(await readConfig()),
-		...config,
+		...(await readConfig(configPath)),
 	} as GeneratorConfig
 
 	const configWithDefaultValues = await getConfigWithDefaultValues(parsedConfig)


### PR DESCRIPTION
Related to https://github.com/ivanhofer/typesafe-i18n/discussions/656

Allow pass additional parameter to `cli` named as `--project`, that allow users to override default `'.typesafe-i18n.json'` path to config file

Save backward compatibility to allow current users change nothing in its workflow.

Tested locally with command
```
typesafe-i18n -p /Users/whalemare/dev/project/some/relative/path/to/config/.typesafe-i18n.json
```