### PR TITLE
feat: add possibility to override default path to config file

### DIFF
--- a/packages/cli/src/cli.mts
+++ b/packages/cli/src/cli.mts
@@ -13,6 +13,7 @@ program.description('CLI to read the base translation file and generate types')
 program.option('--no-watch', 'run the generator only once (CI)')
 program.option('--setup', 'step-by-step setup')
 program.option('--setup-auto', 'auto-guess setup')
+program.option('-p, --project <path>', 'generate translations by configuration file')
 
 program.version(version)
 
@@ -22,12 +23,12 @@ const run = async () => {
 
 	logger.info(`version ${version}`)
 
-	await checkAndUpdateSchemaVersion()
+	await checkAndUpdateSchemaVersion(options.project)
 
 	if (options.setup || options.setupAuto) {
 		await setup(options.setupAuto)
 	} else {
-		startGenerator(undefined, options['watch'])
+		startGenerator(options.project || '.typesafe-i18n.json', options['watch'])
 	}
 }
 

--- a/packages/cli/src/cli.mts
+++ b/packages/cli/src/cli.mts
@@ -1,4 +1,4 @@
-import { Command } from 'commander'
+import { Command, Option } from 'commander'
 import { checkAndUpdateSchemaVersion } from '../../config/src/update-schema-version.mjs'
 import { startGenerator } from '../../generator/src/generator.mjs'
 import { logger } from '../../generator/src/utils/logger.mjs'
@@ -13,7 +13,9 @@ program.description('CLI to read the base translation file and generate types')
 program.option('--no-watch', 'run the generator only once (CI)')
 program.option('--setup', 'step-by-step setup')
 program.option('--setup-auto', 'auto-guess setup')
-program.option('-p, --project <path>', 'generate translations by configuration file')
+program.addOption(
+	new Option('-p, --project <path>', 'path to the config file').default('.typesafe-i18n.json').makeOptionMandatory(),
+)
 
 program.version(version)
 
@@ -28,7 +30,7 @@ const run = async () => {
 	if (options.setup || options.setupAuto) {
 		await setup(options.setupAuto)
 	} else {
-		startGenerator(options.project || '.typesafe-i18n.json', options['watch'])
+		startGenerator(options.project, options['watch'])
 	}
 }
 

--- a/packages/cli/src/setup/setup.mts
+++ b/packages/cli/src/setup/setup.mts
@@ -81,7 +81,7 @@ export const setup = async (autoSetup: boolean) => {
 
 	const config = await getConfigDiff(options)
 
-	await writeConfigToFile(config)
+	await writeConfigToFile(config, '.typesafe-i18n.json')
 	logger.info(`generated config file: '.typesafe-i18n.json'`)
 
 	const installed = await installDependencies()

--- a/packages/config/src/config.mts
+++ b/packages/config/src/config.mts
@@ -5,8 +5,11 @@ import { applyDefaultValues } from './core.mjs'
 import type { GeneratorConfig, GeneratorConfigWithDefaultValues } from './types.mjs'
 import { validateConfig } from './validation.mjs'
 
-export const writeConfigToFile = async (config: GeneratorConfig) =>
-	writeConfigFile({ ...config, $schema: `https://unpkg.com/typesafe-i18n@${version}/schema/typesafe-i18n.json` })
+export const writeConfigToFile = async (config: GeneratorConfig, configPath: string) =>
+	writeConfigFile(
+		{ ...config, $schema: `https://unpkg.com/typesafe-i18n@${version}/schema/typesafe-i18n.json` },
+		configPath,
+	)
 
 export const doesConfigFileExist = async () => doesPathExist(resolve('.typesafe-i18n.json'))
 

--- a/packages/config/src/config.mts
+++ b/packages/config/src/config.mts
@@ -10,11 +10,11 @@ export const writeConfigToFile = async (config: GeneratorConfig) =>
 
 export const doesConfigFileExist = async () => doesPathExist(resolve('.typesafe-i18n.json'))
 
-export const readRawConfig = async () =>
-	(await importFile<GeneratorConfig & { $schema?: string }>(resolve('.typesafe-i18n.json'), false)) || {}
+export const readRawConfig = async (configPath: string) =>
+	(await importFile<GeneratorConfig & { $schema?: string }>(resolve(configPath), false)) || {}
 
-export const readConfig = async (): Promise<GeneratorConfig> => {
-	const generatorConfig = await readRawConfig()
+export const readConfig = async (configPath = '.typesafe-i18n.json'): Promise<GeneratorConfig> => {
+	const generatorConfig = await readRawConfig(configPath)
 
 	// remove "$schema" property
 	const configWithoutSchemaAttribute = Object.fromEntries(

--- a/packages/config/src/core.mts
+++ b/packages/config/src/core.mts
@@ -23,22 +23,22 @@ export const applyDefaultValues = async (
 	...(config as unknown as any),
 })
 
-const readConfigFromDisk = async (fs: FileSystemUtil) => {
-	const content = await fs.readFile('.typesafe-i18n.json').catch(() => '{}')
+const readConfigFromDisk = async (fs: FileSystemUtil, configPath: string) => {
+	const content = await fs.readFile(configPath).catch(() => '{}')
 
 	return JSON.parse(content.toString()) as GeneratorConfig & { $schema?: string }
 }
 
-export const getConfig = async (fs: FileSystemUtil) => {
-	const config = await readConfigFromDisk(fs)
+export const getConfig = async (fs: FileSystemUtil, configPath = '.typesafe-i18n.json') => {
+	const config = await readConfigFromDisk(fs, configPath)
 
 	return applyDefaultValues(config)
 }
 
 // --------------------------------------------------------------------------------------------------------------------
 
-export const getLocaleInformation = async (fs: FileSystemUtil) => {
-	const config = await getConfig(fs)
+export const getLocaleInformation = async (fs: FileSystemUtil, configPath = '.typesafe-i18n.json') => {
+	const config = await getConfig(fs, configPath)
 
 	return {
 		base: config.baseLocale,

--- a/packages/config/src/update-schema-version.mts
+++ b/packages/config/src/update-schema-version.mts
@@ -2,8 +2,8 @@ import { logger } from '../../generator/src/utils/logger.mjs'
 import { version } from '../../version'
 import { readRawConfig, writeConfigToFile } from './config.mjs'
 
-export const checkAndUpdateSchemaVersion = async () => {
-	const config = await readRawConfig()
+export const checkAndUpdateSchemaVersion = async (configPath = '.typesafe-i18n.json') => {
+	const config = await readRawConfig(configPath)
 
 	if (!config.$schema) return
 
@@ -11,5 +11,5 @@ export const checkAndUpdateSchemaVersion = async () => {
 
 	await writeConfigToFile(config)
 
-	logger.info(`updated '$schema' version of '.typesafe-i18n.json' to '${version}'`)
+	logger.info(`updated '$schema' version of '${configPath}' to '${version}'`)
 }

--- a/packages/config/src/update-schema-version.mts
+++ b/packages/config/src/update-schema-version.mts
@@ -9,7 +9,7 @@ export const checkAndUpdateSchemaVersion = async (configPath = '.typesafe-i18n.j
 
 	if (config.$schema.includes(version)) return
 
-	await writeConfigToFile(config)
+	await writeConfigToFile(config, configPath)
 
 	logger.info(`updated '$schema' version of '${configPath}' to '${version}'`)
 }

--- a/packages/generator/src/generator.mts
+++ b/packages/generator/src/generator.mts
@@ -99,12 +99,11 @@ const debounce = (callback: () => void) =>
 		++debounceCounter,
 	)
 
-export const startGenerator = async (config?: GeneratorConfig, watchFiles = true): Promise<void> => {
+export const startGenerator = async (configPath: string, watchFiles = true): Promise<void> => {
 	logger = createLogger(console, !watchFiles)
 
 	const parsedConfig = {
-		...(await readConfig()),
-		...config,
+		...(await readConfig(configPath)),
 	} as GeneratorConfig
 
 	const configWithDefaultValues = await getConfigWithDefaultValues(parsedConfig)

--- a/packages/generator/src/utils/file.utils.mts
+++ b/packages/generator/src/utils/file.utils.mts
@@ -56,8 +56,8 @@ export const deleteFolderRecursive = async (path: string): Promise<boolean> => {
 
 export const writeFile = (filePath: string, content: string) => write(filePath, content, { encoding: 'utf-8' })
 
-export const writeConfigFile = async (content: JsonObject) =>
-	writeFile(resolve('./', '.typesafe-i18n.json'), JSON.stringify(content, undefined, 3))
+export const writeConfigFile = async (content: JsonObject, configPath: string) =>
+	writeFile(resolve('./', configPath), JSON.stringify(content, undefined, 3))
 
 const getFileName = (path: string, file: string) => {
 	const ext = file.endsWith(fileEnding) || file.endsWith(`${fileEnding}x`) || file.endsWith('.d.ts') ? '' : fileEnding


### PR DESCRIPTION
Related to https://github.com/ivanhofer/typesafe-i18n/discussions/656

Allow pass additional parameter to `cli` named as `--project`, that allow users to override default `'.typesafe-i18n.json'` path to config file

Save backward compatibility to allow current users change nothing in it's workflow.

Tested locally with command
```
typesafe-i18n -p /Users/whalemare/dev/project/some/relative/path/to/config/.typesafe-i18n.json
```