### PR TITLE
docs: add example for JS + JSDocs for SvelteKit

### DIFF
--- a/packages/adapter-svelte/README.md
+++ b/packages/adapter-svelte/README.md
@@ -173,8 +173,8 @@ If you want to change the locale, you need to call `setLocale` with the locale a
 
 # SvelteKit
 
-See [here](https://github.com/ivanhofer/typesafe-i18n-demo-sveltekit)
-
+- See SvelteKit with TypeScript example [here](https://github.com/ivanhofer/typesafe-i18n-demo-sveltekit)
+- See SvelteKit with JavaScript + JSDocs example [here](https://github.com/ivanhofer/typesafe-i18n-demo-sveltekit-jsdoc)
 
 <!-- ------------------------------------------------------------------------------------------ -->
 <!-- ------------------------------------------------------------------------------------------ -->


### PR DESCRIPTION
- Adds link to example for SvelteKit with JS + JSDocs
- Rephrases text for link of SvelteKit with TS

Relates to https://github.com/ivanhofer/typesafe-i18n/discussions/717#discussioncomment-6640503