### PR TITLE
docs: Fix table in generator's README

### DIFF
--- a/packages/generator/README.md
+++ b/packages/generator/README.md
@@ -207,11 +207,11 @@ The available options are:
 
 | key                                                       | type                                                                                             | default value                                 |
 | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------- |
-| [adapter](#adapter)                                       | `'angular'  \| 'node'  \| 'react'  \| 'solid'  \| 'svelte'  \| 'vue'  \| undefined` | `undefined`                                   |
-| [adapters](#adapters)                                       | `Array<'angular' \| 'node' \| 'react' \| 'solid' \| 'svelte' \| 'vue'> \| undefined`                           | `undefined`
+| [adapter](#adapter)                                       | `'angular'  \| 'node'  \| 'react'  \| 'solid'  \| 'svelte'  \| 'vue'  \| undefined` | `undefined`| `undefined`                                   |
+| [adapters](#adapters)                                     | `Array<'angular' \| 'node' \| 'react' \| 'solid' \| 'svelte' \| 'vue'> \| undefined`             | `undefined`                                   |
 | [baseLocale](#baselocale)                                 | `string`                                                                                         | `'en'`                                        |
 | [outputFormat](#outputformat)                             | `'TypeScript'` &#124; `'JavaScript'`                                                             | `'TypeScript'`                                |
-| [esmImports](#esmimports)                                 | `boolean | '.js' | 'fileEnding'                                                                                        | `false`                                       |
+| [esmImports](#esmimports)                                 | `boolean` &#124; `'.js'` &#124; `'fileEnding'`                                                   | `false`                                       |
 | [generateOnlyTypes](#generateonlytypes)                   | `boolean`                                                                                        | `false`                                       |
 | [runAfterGenerator](#runaftergenerator)                   | `string` &#124; `undefined`                                                                      | `undefined`                                   |
 | [banner](#banner)                                         | `string`                                                                                         | `'/* eslint-disable */'`                      |


### PR DESCRIPTION
Hi, 

I was browsing the docs and found something weird. Then checked the sources and found a wrong escaping. Fixed this row, also aligned the width of all rows in the source code. There are screenshots of before and after:

![image](https://github.com/ivanhofer/typesafe-i18n/assets/9670990/54b7443e-9d2c-4cdd-8420-68110a2a2faf)
![image](https://github.com/ivanhofer/typesafe-i18n/assets/9670990/fc14ea2f-4aff-40f9-a14e-7e317baac947)

And the table in markdown is now pretty: 
<img width="1542" alt="image" src="https://github.com/ivanhofer/typesafe-i18n/assets/9670990/179ce1fe-c9b0-45db-b863-f2f45ce27093">
