### PR TITLE
fix: TS1479 error

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"nodejs"
 	],
 	"license": "MIT",
+	"type": "module",
 	"module": "runtime/esm/runtime/src/index.mjs",
 	"main": "runtime/cjs/runtime/src/index.cjs",
 	"types": "types/index.d.ts",


### PR DESCRIPTION
Fixes https://github.com/ivanhofer/typesafe-i18n/issues/756.

### Key Change:
- Addition of `"type": "module"` in `package.json`.

### Issue Background:
- The problem arises due to TypeScript's reliance on the `package.json` `type` field to determine the module format (CommonJS or ECMAScript Module, ESM) of a project.
- In the absence of the `type` field, TypeScript, along with Node.js, defaults to interpreting modules as CommonJS. This becomes an issue when dealing with `.d.ts` files, as they do not specify the module system (like `.mjs` or `.cjs` would).
- Consequently, when an ESM is imported in such a scenario, TypeScript incorrectly assumes it to be a CommonJS module, leading to module resolution conflicts described in https://github.com/ivanhofer/typesafe-i18n/issues/756.



Thank you for considering this pull request!
