### PR TITLE
fix: TypeScript 6 defaults module to "esnext"

### DIFF
--- a/packages/generator/src/parse-language-file.mts
+++ b/packages/generator/src/parse-language-file.mts
@@ -89,6 +89,7 @@ const transpileTypescriptFiles = async (
 		skipLibCheck: true,
 		sourceMap: false,
 		noLib: true,
+		module: ts.ModuleKind.CommonJS,
 	})
 
 	program.emit()


### PR DESCRIPTION
TypeScript 6 changed the default module to "esnext" (previously it was CommonJS) - reference: https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/

In our setup, we imported another file in our /en/index.ts file:
```
import en from './en';
export default en;
```

after upgrading to TypeScript 6, generating the language files failed.
More details can be found in the corresponding issue: https://github.com/codingcommons/typesafe-i18n/issues/789

The fix sets the module option to use CommonJS (which was used implicitly before anyway).

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

## generator

If you change something in the `generator`, please also:
 - add some snapshot tests to the `packages/generator/test/generator.test.ts`-file
 - then run `pnpm test` => you should see your tests failing
 - run `pnpm test:update-generated-files`
 - again run `pnpm test` => your tests should pass
 - then add all the created `*.expected.*`-files to the git-index and
 - make sure these files look like you would expect them
 - finally commit these files to the repository