### PR TITLE
fix: sort discovered locales for deterministic generator output

### DIFF
--- a/packages/generator/test/get-all-locales.test.ts
+++ b/packages/generator/test/get-all-locales.test.ts
@@ -1,0 +1,44 @@
+import { suite } from 'uvu'
+import * as assert from 'uvu/assert'
+import { getAllLocales, type FileSystemUtil } from '../../shared/src/file.utils.mjs'
+
+const test = suite('getAllLocales')
+
+type Dirent = { name: string; isDirectory: () => boolean }
+
+const folder = (name: string): Dirent => ({ name, isDirectory: () => true })
+const file = (name: string): Dirent => ({ name, isDirectory: () => false })
+
+const ROOT = './i18n'
+
+// the order in which the filesystem returns directory entries is not guaranteed
+// to be stable across platforms or runs, so `getAllLocales` must sort the result
+// to produce a deterministic output
+const createFileSystem = (rootEntries: Dirent[]): FileSystemUtil => ({
+	readFile: async () => '',
+	readdir: async (path) => (String(path) === ROOT ? rootEntries : [file('index.ts')]),
+})
+
+test('returns the discovered locales sorted alphabetically', async () => {
+	const fs = createFileSystem([folder('sk'), folder('cs'), folder('en')])
+
+	assert.equal(await getAllLocales(fs, ROOT, 'TypeScript'), ['cs', 'en', 'sk'])
+})
+
+test('sorts locales independently of the filesystem order', async () => {
+	const ascending = createFileSystem([folder('cs'), folder('en'), folder('sk')])
+	const descending = createFileSystem([folder('sk'), folder('en'), folder('cs')])
+
+	assert.equal(await getAllLocales(ascending, ROOT, 'TypeScript'), await getAllLocales(descending, ROOT, 'TypeScript'))
+})
+
+test('also sorts when looking for JavaScript locale files', async () => {
+	const fs: FileSystemUtil = {
+		readFile: async () => '',
+		readdir: async (path) => (String(path) === ROOT ? [folder('sk'), folder('cs')] : [file('index.js')]),
+	}
+
+	assert.equal(await getAllLocales(fs, ROOT, 'JavaScript'), ['cs', 'sk'])
+})
+
+test.run()

--- a/packages/shared/src/file.utils.mts
+++ b/packages/shared/src/file.utils.mts
@@ -38,5 +38,8 @@ export const getAllLocales = async (
 	const fileEnding = outputFormat === 'JavaScript' ? '.js' : '.ts'
 	const files = await getFiles(fs, path, 1)
 
-	return files.filter(({ folder, name }) => folder && name === `index${fileEnding}`).map(({ folder }) => folder)
+	return files
+		.filter(({ folder, name }) => folder && name === `index${fileEnding}`)
+		.map(({ folder }) => folder)
+		.sort()
 }


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

## Problem

`getAllLocales` (in `packages/shared/src/file.utils.mts`) returns the locale
folders in the order `fs.readdir` happens to yield them. That order is
filesystem-dependent and is **not** guaranteed to be stable across platforms
or even across runs on the same machine (e.g. APFS on macOS).

Because this order flows directly into the generated output, the `Locales`
union type and the `locales` array get reordered whenever types are
regenerated — even when no translations changed. For projects that commit
their generated `i18n-types.ts` / `i18n-util.ts`, this produces recurring,
noisy diffs like:

```diff
 export type Locales =
+	| 'cs'
 	| 'en'
-	| 'cs'
 	| 'sk'
```

## Fix

Sort the discovered locale folder names so the generated output is
deterministic regardless of the order returned by `fs.readdir`. This is a
single `.sort()` on the resulting `string[]`.

## Tests

Added `packages/generator/test/get-all-locales.test.ts`, which feeds
`getAllLocales` a mocked filesystem returning locale folders in an unsorted
order and asserts the result is sorted and independent of the input order.
The test fails on `main` and passes with this change.

`pnpm test` (generator suite, 103 tests) and `pnpm lint` pass locally.