### PR TITLE
fix: updated extendDictionary to be truly deep and fixed tests

### DIFF
--- a/packages/utils/src/extendDictionary.mts
+++ b/packages/utils/src/extendDictionary.mts
@@ -21,6 +21,6 @@ export const initExtendDictionary =
 		base: Base,
 		part: DeepPartial<ToGenericString<Translation>>,
 	): Translation =>
-		extend({}, base, part) as Translation
+		extend(true, {}, base, part) as Translation
 
 export const extendDictionary = initExtendDictionary()

--- a/packages/utils/src/extendDictionary.test.ts
+++ b/packages/utils/src/extendDictionary.test.ts
@@ -7,7 +7,7 @@ const test = suite('utils')
 
 const translation = {
 	simple: 'Hello',
-	nested: { value: 'Hello nested' },
+	nested: { value: 'Hello nested', otherValue: 'Hello nested again' },
 }
 
 test('does no mutation', () => {
@@ -37,6 +37,7 @@ test('simple extend', () => {
 		simple: 'Hello extended',
 		nested: {
 			value: 'Hello nested',
+			otherValue: 'Hello nested again',
 		},
 	})
 })
@@ -47,6 +48,7 @@ test('nested extend', () => {
 		simple: 'Hello',
 		nested: {
 			value: 'Hello nested extended',
+			otherValue: 'Hello nested again',
 		},
 	})
 })
@@ -60,6 +62,7 @@ test('nested extend with simple', () => {
 		simple: 'Hello extended',
 		nested: {
 			value: 'Hello nested extended',
+			otherValue: 'Hello nested again',
 		},
 	})
 })
@@ -74,6 +77,7 @@ test('add prop', () => {
 		add: 'test',
 		nested: {
 			value: 'Hello nested',
+			otherValue: 'Hello nested again',
 		},
 	})
 })
@@ -92,6 +96,7 @@ test('add nested prop', () => {
 		},
 		nested: {
 			value: 'Hello nested',
+			otherValue: 'Hello nested again',
 		},
 	})
 })


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

## Bug
- The extendDictionary was not really doing deep extend. It just replaced the top-level properties.
<img width="381" height="226" alt="obrazek" src="https://github.com/user-attachments/assets/e1a189f5-d5ad-473f-9176-5012db6ed315" />


## Solution
- I added true as a first argument to the call of extend function from [just-extend](https://www.npmjs.com/package/just-extend) package to do the desired deep extend.
- Also I updated the tests, because they were not catching this issue.
<img width="291" height="125" alt="obrazek" src="https://github.com/user-attachments/assets/15a53ca4-544f-40d8-b0de-ed3661d012b3" />
